### PR TITLE
Feature/cloud store

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,3 +7,7 @@ LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_BASE_URL=https://cloud.langfuse.com
 LLAMA_CLOUD_API_KEY=your_key_here
+CLOUDFLARE_ACCOUNT_ID=your_key_here
+R2_ACCESS_KEY_ID=your_key_here
+R2_SECRET_ACCESS_KEY=your_key_here
+R2_BUCKET_NAME=multiagentsynthesis

--- a/README.md
+++ b/README.md
@@ -67,11 +67,22 @@ python main.py --gemini
 
 ### Document processor
 
-While there are multiple backends for document processing are implemented, due to requirement conflicts only LlamaParse is available with the provided requirements.txt.  Other backends will need additional dependencies, and likely separate environments.
+While there are multiple backends for document processing are implemented, due to requirement conflicts only LlamaParse is available with the provided requirements.txt. Other backends will need additional dependencies, and likely separate environments.
 
 For LlamaParse, set **`LLAMA_CLOUD_API_KEY`** in your environment.
 
 Optional **`--text-splitter`** controls chunking after parse: `none` (single chunk from full text) or `semantic` (default, semantic splitter). Only use this if the document processor does not natively support chunking (LLamaparse for now).
+
+### Cloud storage
+
+Project has an optional [Cloudflare R2 Storage](https://developers.cloudflare.com/r2/get-started/s3/) for images extracted from document processors and a local storage. To use the cloud store, set up your API keys and credentials as follow:
+
+```
+CLOUDFLARE_ACCOUNT_ID=your_key_here
+R2_ACCESS_KEY_ID=your_key_here
+R2_SECRET_ACCESS_KEY=your_key_here
+R2_BUCKET_NAME=multiagentsynthesis
+```
 
 ### Optional Commandline Arguments
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from src.llm import GLOBAL_CONFIG, Provider
 from src.logging.logger import AgentLogger
 from src.memory.wip.database import WIPDatabase
+from src.memory.objectstore import LocalObjectStore, R2ObjectStore, DEFAULT_OBJECT_STORE_CONFIG
 
 DEFAULT_QUERY = "Explain what Transformers are and how they are so important to AI"
 DEFAULT_SOURCE_PDF = "./.samples/Transformers.pdf"
@@ -77,6 +78,13 @@ def _parse_args() -> argparse.Namespace:
         default=True,
         help="Enable/disable Langfuse logging"
     )
+    parser.add_argument(
+        "--object-store",
+        type=str,
+        choices=["local", "r2"],
+        default=None,  # Default behavior remains as before (R2 with fallback to local)
+        help="Object store type: 'local' for local filesystem, 'r2' for Cloudflare R2 (default: R2 with local fallback)"
+    )
     return parser.parse_args()
 
 def _get_callbacks(args, logger: AgentLogger):
@@ -107,17 +115,35 @@ def _process_document(args: argparse.Namespace, logger: AgentLogger) -> tuple[An
         sys.exit(f"error: PDF not found: {pdf_path}")
     if pdf_path.suffix.lower() != ".pdf":
         sys.exit(f"error: file does not have a .pdf extension: {pdf_path}")
-    
+
     _t0 = time.perf_counter()
+
+    # Initialize object store based on CLI argument
+    if args.object_store == "local":
+        object_store = LocalObjectStore(config=DEFAULT_OBJECT_STORE_CONFIG)
+        logger.log("Using LocalObjectStore for image storage (explicitly selected)", level="info")
+    elif args.object_store == "r2":
+        r2_config = DEFAULT_OBJECT_STORE_CONFIG
+        object_store = R2ObjectStore(config=r2_config)
+        logger.log("Using R2ObjectStore for image storage (explicitly selected)", level="info")
+    else:  # Default behavior
+        try:
+            r2_config = DEFAULT_OBJECT_STORE_CONFIG
+            object_store = R2ObjectStore(config=r2_config)
+            logger.log("Using R2ObjectStore for image storage (default behavior)", level="info")
+        except Exception as e:
+            logger.log(f"R2ObjectStore initialization failed: {str(e)}. Falling back to LocalObjectStore.", level="warning")
+            object_store = LocalObjectStore(config=DEFAULT_OBJECT_STORE_CONFIG)
+
     db = get_database()
     embedder = get_text_embedder()
     processor_backend = _PROCESSOR_BACKEND_ALIASES[args.processor]
     chunker_name = _TEXT_SPLITTER_ALIASES[args.text_splitter]
-    
+
     # default to 'semantic' chunking if using LlamaParser and no specific splitter chosen
     if not chunker_name and processor_backend == "llama_parse":
         chunker_name = "semantic"
-        
+
     text_chunker = get_text_chunker(chunker_name) if chunker_name else None
     processor = DocProcessor(
         backend=processor_backend,
@@ -125,14 +151,15 @@ def _process_document(args: argparse.Namespace, logger: AgentLogger) -> tuple[An
         db=db,
         embedder=embedder,
         logger=logger,
+        object_store=object_store,
     )
     artifacts = processor.process_document(str(pdf_path))
-        
+
     _pdf_elapsed = time.perf_counter() - _t0
-    
+
     if artifacts and artifacts.chunk_count > 0:
         print(f"[preprocessing] PDF extraction/pipeline completed in {_pdf_elapsed:.2f}s", flush=True)
-        
+
     if args.interactive:
         try:
             response = input("Press Enter to continue, or type 'q' to quit: ").strip().lower()
@@ -140,9 +167,9 @@ def _process_document(args: argparse.Namespace, logger: AgentLogger) -> tuple[An
             sys.exit("\nAborted.")
         if response == "q":
             sys.exit("Execution stopped by user.")
-    
+
     status = "Processed" if artifacts and artifacts.chunk_count > 0 else "FAILED TO PROCESS (running without documents)"
-    
+
     if artifacts:
         preprocessing_message = (
             f"[preprocessing] {status} multimodal artifacts "
@@ -151,7 +178,7 @@ def _process_document(args: argparse.Namespace, logger: AgentLogger) -> tuple[An
         )
     else:
         preprocessing_message = f"[preprocessing] {status}"
-        
+
     return artifacts, preprocessing_message
 
 def _build_initial_state(args: argparse.Namespace, preprocessing_message: str, artifacts: Any) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ langchain>=0.2,<1.0
 sentence-transformers>=3.0,<4.0
 llama-cloud
 semantic-text-splitter
+boto3>=1.34.0
+tenacity>=8.0.0

--- a/src/memory/objectstore/__init__.py
+++ b/src/memory/objectstore/__init__.py
@@ -1,10 +1,12 @@
 from .config import DEFAULT_OBJECT_STORE_CONFIG, ObjectStoreConfig
 from .local_store import LocalObjectStore
 from .provider import ObjectStoreProvider
+from .r2_store import R2ObjectStore
 
 __all__ = [
     "ObjectStoreProvider",
     "ObjectStoreConfig",
     "DEFAULT_OBJECT_STORE_CONFIG",
     "LocalObjectStore",
+    "R2ObjectStore",
 ]

--- a/src/memory/objectstore/config.py
+++ b/src/memory/objectstore/config.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import os
 
 
 @dataclass
 class ObjectStoreConfig:
     root_path: Path = Path("data/objectstore")
     auto_create_dirs: bool = True
+    r2_bucket_name: str = ""
 
 
 DEFAULT_OBJECT_STORE_CONFIG = ObjectStoreConfig()

--- a/src/memory/objectstore/r2_store.py
+++ b/src/memory/objectstore/r2_store.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError, NoCredentialsError
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+
+from .config import ObjectStoreConfig
+from .provider import ObjectStoreProvider
+
+# Import logger - assumes this module is imported as part of the package
+try:
+    from src.logging.logger import AgentLogger
+except ImportError:
+    import logging
+    AgentLogger = logging.getLogger
+
+
+class R2ObjectStore(ObjectStoreProvider):
+    """Cloudflare R2 object store implementation using boto3 S3-compatible API."""
+
+    def __init__(self, config: ObjectStoreConfig) -> None:
+        self._config = config
+        self._logger = AgentLogger()
+
+        # Get R2 configuration from environment variables
+        self._account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
+        self._access_key_id = os.getenv("R2_ACCESS_KEY_ID")
+        self._secret_access_key = os.getenv("R2_SECRET_ACCESS_KEY")
+        self._bucket_name = os.getenv("R2_BUCKET_NAME", config.r2_bucket_name)
+
+        # Validate required configuration
+        if not all([self._account_id, self._access_key_id, self._secret_access_key, self._bucket_name]):
+            raise ValueError(
+                "R2 configuration missing. Required: CLOUDFLARE_ACCOUNT_ID, R2_ACCESS_KEY_ID, "
+                "R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME"
+            )
+
+        # Construct R2 endpoint URL
+        self._endpoint_url = f"https://{self._account_id}.r2.cloudflarestorage.com"
+
+        # Configure boto3 client with retries
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=self._endpoint_url,
+            aws_access_key_id=self._access_key_id,
+            aws_secret_access_key=self._secret_access_key,
+            region_name="auto",  # R2 uses "auto" for region
+            config=Config(
+                retries={
+                    "max_attempts": 3,
+                    "mode": "standard"
+                }
+            )
+        )
+
+        self._logger.log(f"R2ObjectStore initialized for bucket: {self._bucket_name}", level="info")
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((ClientError, ConnectionError)),
+        reraise=True
+    )
+    def write(self, key: str, data: bytes) -> str:
+        """
+        Upload data to R2 bucket.
+
+        Args:
+            key: Object key in format "{document_id}/{image_id}.{extension}"
+            data: Binary data to upload
+
+        Returns:
+            Public URL of the uploaded object
+
+        Raises:
+            ClientError: If upload fails after retries
+        """
+        try:
+            self._client.put_object(
+                Bucket=self._bucket_name,
+                Key=key,
+                Body=data
+            )
+
+            # Construct public URL
+            public_url = f"https://pub-{self._bucket_name}.r2.dev/{key}"
+
+            self._logger.log(f"Successfully uploaded object to R2: {key} -> {public_url}", level="info")
+            return public_url
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            self._logger.log(f"R2 upload failed for key '{key}': {error_code} - {str(e)}", level="error")
+            raise
+        except NoCredentialsError:
+            self._logger.log(f"R2 upload failed: missing credentials for key '{key}'", level="error")
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((ClientError, ConnectionError)),
+        reraise=True
+    )
+    def read(self, key: str) -> bytes:
+        """
+        Download data from R2 bucket.
+
+        Args:
+            key: Object key in format "{document_id}/{image_id}.{extension}" or full R2 URL
+
+        Returns:
+            Binary data from the object
+
+        Raises:
+            FileNotFoundError: If object does not exist
+            ClientError: If download fails after retries
+        """
+        # Extract key from URL if a full URL is provided
+        object_key = key
+        if key.startswith("http"):
+            parsed = urlparse(key)
+            # R2 public URL format: https://pub-{bucket}.r2.dev/{key}
+            object_key = parsed.path.lstrip("/")
+
+        try:
+            response = self._client.get_object(
+                Bucket=self._bucket_name,
+                Key=object_key
+            )
+            data = response["Body"].read()
+
+            self._logger.log(f"Successfully read object from R2: {object_key}", level="info")
+            return data
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code == "404":
+                self._logger.log(f"R2 object not found: {object_key}", level="warning")
+                raise FileNotFoundError(f"Object not found in R2: {object_key}")
+            self._logger.log(f"R2 download failed for key '{object_key}': {error_code} - {str(e)}", level="error")
+            raise
+        except NoCredentialsError:
+            self._logger.log(f"R2 download failed: missing credentials for key '{object_key}'", level="error")
+            raise

--- a/src/memory/objectstore/r2_store.py
+++ b/src/memory/objectstore/r2_store.py
@@ -140,7 +140,7 @@ class R2ObjectStore(ObjectStoreProvider):
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            if error_code == "404":
+            if error_code in ["404", "NoSuchKey"]:
                 self._logger.log(f"R2 object not found: {object_key}", level="warning")
                 raise FileNotFoundError(f"Object not found in R2: {object_key}")
             self._logger.log(f"R2 download failed for key '{object_key}': {error_code} - {str(e)}", level="error")

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -189,8 +189,8 @@ class ResearchDatabase(DatabaseProvider):
             for img in result.images:
                 self._conn.execute(
                     """
-                    INSERT OR REPLACE INTO images 
-                    (id, document_id, mime_type, base64_data, page_number, caption, local_path, contextualized_text) 
+                    INSERT OR REPLACE INTO images
+                    (id, document_id, mime_type, base64_data, storage_path, page_number, caption, contextualized_text)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
@@ -198,9 +198,9 @@ class ResearchDatabase(DatabaseProvider):
                         doc_id,
                         img.mime_type,
                         img.base64_data,
+                        img.storage_path,
                         img.page,
                         img.caption,
-                        img.local_path,
                         img.contextualized_text,
                     )
                 )
@@ -303,11 +303,11 @@ class ResearchDatabase(DatabaseProvider):
             ExtractedImage(
                 id=row["id"],
                 mime_type=row["mime_type"],
-                base64_data=row["base64_data"],
+                base64_data=row["base64_data"] or "",
                 page=row["page_number"],
                 caption=row["caption"] or "",
-                local_path=row["local_path"],
-                contextualized_text=row["contextualized_text"]
+                storage_path=row["storage_path"],
+                contextualized_text=row["contextualized_text"],
             ) for row in img_rows
         ]
 
@@ -378,11 +378,11 @@ class ResearchDatabase(DatabaseProvider):
         return ExtractedImage(
             id=row["id"],
             mime_type=row["mime_type"],
-            base64_data=row["base64_data"],
+            base64_data=row["base64_data"] or "",
             page=row["page_number"],
             caption=row["caption"] or "",
-            local_path=row["local_path"],
-            contextualized_text=row["contextualized_text"]
+            storage_path=row["storage_path"],
+            contextualized_text=row["contextualized_text"],
         )
 
     def get_table(self, table_id: str) -> ExtractedTable | None:

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -17,16 +17,16 @@ CREATE TABLE IF NOT EXISTS documents (
 );
 """
 
-# Images table stores extracted image data as base64 TEXT
+# Images table stores extracted image data
 CREATE_IMAGES_TABLE = """
 CREATE TABLE IF NOT EXISTS images (
     id TEXT PRIMARY KEY,
     document_id TEXT NOT NULL,
     mime_type TEXT NOT NULL,
-    base64_data TEXT NOT NULL,
+    base64_data TEXT,
+    storage_path TEXT,
     page_number INTEGER,
     caption TEXT,
-    local_path TEXT,
     contextualized_text TEXT,
     FOREIGN KEY (document_id) REFERENCES documents(id)
 );

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -707,13 +707,13 @@ class LlamaParseBackend(OCRBackend):
             img_id = f"{doc_id}_img_{index + 1:03d}"
             ext = _extension(filename, mime_type)
             storage_key = f"{doc_id}/images/{img_id}.{ext}"
-            local_path: str | None = None
+            storage_path: str | None = None
             base64_data = ""
             try:
-                self._object_store.write(storage_key, image_bytes)
-                local_path = storage_key
+                storage_path = self._object_store.write(storage_key, image_bytes)
             except Exception as exc:
-                print(f"[LlamaParseBackend] Failed to store image {filename}: {exc}")
+                print(f"[LlamaParseBackend] Failed to store image {filename} in object store: {exc}")
+                # Fallback to storing as base64 data
                 base64_data = base64.b64encode(image_bytes).decode("utf-8")
 
             extracted.append(ExtractedImage(
@@ -722,7 +722,7 @@ class LlamaParseBackend(OCRBackend):
                 base64_data=base64_data,
                 page=page_num,
                 caption=caption,
-                local_path=local_path,
+                storage_path=storage_path,
             ))
 
         return extracted

--- a/src/processing/document/processor.py
+++ b/src/processing/document/processor.py
@@ -30,6 +30,7 @@ def get_ocr_backend(
     name: str = "llama_parse",
     text_chunker: TextChunkerProvider | None = None,
     logger: AgentLogger | None = None,
+    object_store: Any = None,
 ) -> OCRBackend:
     """Instantiate an OCR backend by name."""
     cls = BACKEND_REGISTRY.get(name)
@@ -39,7 +40,7 @@ def get_ocr_backend(
             f"Available: {list(BACKEND_REGISTRY.keys())}"
         )
     if cls is LlamaParseBackend:
-        return cls(text_chunker=text_chunker, logger=logger)
+        return cls(text_chunker=text_chunker, logger=logger, object_store=object_store)
     return cls()
 
 
@@ -58,6 +59,7 @@ class DocProcessor:
         contextualizer: Contextualizer | None = None,
         embedder: TextEmbedder | None = None,
         logger: AgentLogger | None = None,
+        object_store: Any = None,
     ):
         """
         Create a document processor with the given OCR backend and optional pipeline stages.
@@ -65,7 +67,7 @@ class DocProcessor:
         """
         self._logger = logger or AgentLogger()
         if isinstance(backend, str):
-            self.backend = get_ocr_backend(backend, text_chunker=text_chunker, logger=self._logger)
+            self.backend = get_ocr_backend(backend, text_chunker=text_chunker, logger=self._logger, object_store=object_store)
         else:
             self.backend = backend
         self._db = db

--- a/src/processing/document/schema.py
+++ b/src/processing/document/schema.py
@@ -13,7 +13,7 @@ class ExtractedImage:
         base64_data: The raw base64 encoded string of the image
         page: 1-indexed page number where the image was found
         caption: Extracted caption text associated with the figure (from ImageItem.caption)
-        local_path: Path where the image file is stored (local now, cloud key later)
+        storage_path: Path/URL where the image file is stored (local path or cloud URL)
         contextualized_text: Succinct context situated within the document
     """
     id: str
@@ -21,7 +21,7 @@ class ExtractedImage:
     base64_data: str
     page: int | None = None
     caption: str = ""
-    local_path: str | None = None
+    storage_path: str | None = None
     contextualized_text: str | None = None
 
 


### PR DESCRIPTION
**Overview**
Create a Cloudflare R2 client to store images as an alternative to the current local image object store.
API setup guide can be found [here](https://developers.cloudflare.com/r2/get-started/s3/)

**Why**
- Storing base64 data is flaky (bloats up the database with massive bytes, and hard to inject into agent context when retrieving)
- Storing images locally is hard to transfer, and could add more complicated file i/o and network handling when sending to agent

**New expected log output**
```
Langfuse client is disabled. No observability data will be sent.
R2ObjectStore initialized for bucket: multiagentsynthesis
Using R2ObjectStore for image storage
[DocProcessor] Extracting .samples\Transformers.pdf...
[LlamaParseBackend] Parse job created id=pjb-1llqwu27amr9z0884ltv9o0frbgy
[LlamaParseBackend] Wrote raw parse result to artifacts\llamaparse_raw_Transformers_pjb-1llqwu27amr9z0884ltv9o0frbgy.json
Successfully uploaded object to R2: Transformers/images/Transformers_img_001.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_001.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_002.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_002.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_003.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_003.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_004.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_004.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_005.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_005.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_006.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_006.jpg
ultiagentsynthesis.r2.dev/Transformers/images/Transformers_img_007.jpg
Successfully uploaded object to R2: Transformers/images/Transformers_img_008.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_008.jpg  
Successfully uploaded object to R2: Transformers/images/Transformers_img_009.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_009.jpg  
Successfully uploaded object to R2: Transformers/images/Transformers_img_010.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_010.jpg  
Successfully uploaded object to R2: Transformers/images/Transformers_img_011.jpg -> https://pub-multiagentsynthesis.r2.dev/Transformers/images/Transformers_img_011.jpg  
[LlamaParseBackend] Rewrote markdown refs: url_mapped=22 caption_mapped=1 pages_with_images=9 table_tokens=6
[DocProcessor] Embedding chunks...
[DocProcessor] Embedding input chunks=28
[DocProcessor] Embeddings generated count=28 dim=768
[DocProcessor] Sanity Check: Found 7 media tokens in chunks.
[DocProcessor] Wrote debug ExtractionResult to artifacts\last_extraction_result_pjb-1llqwu27amr9z0884ltv9o0frbgy.json
[DocProcessor] Storing to database...
[ResearchDatabase] Writing embeddings doc_id=Transformers chunks=28 embs=28 dim_expected=768
[ResearchDatabase] Embeddings write complete doc_id=Transformers inserted=28 skipped_dim=0
[preprocessing] PDF extraction/pipeline completed in 68.25s
```
**Example storage**
<img width="1886" height="823" alt="image" src="https://github.com/user-attachments/assets/f9f0898b-2785-48a5-9404-eab8fe3fe3fc" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new R2-backed image storage path and changes the DB schema/serialization for images, which could break existing data or retrieval if migrations aren’t handled. Also changes `main.py` execution flow by commenting out graph running, which may unintentionally disable the core workflow.
> 
> **Overview**
> Adds optional Cloudflare R2 object storage for extracted images via a new `R2ObjectStore` (boto3 + tenacity retries) and wires it through `main.py` (`--object-store`), `DocProcessor`, and `LlamaParseBackend`, with fallback to base64 when storage fails.
> 
> Updates image persistence to store `storage_path` (local path or R2 public URL) and makes `base64_data` optional in the SQLite `images` table, plus updates env/docs and dependencies (`boto3`, `tenacity`) to support R2 configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68371b95f419051ed4eeebe992d47d86577a9308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->