### PR TITLE
Feature/pandoc implementation

### DIFF
--- a/.design/presentation_export.md
+++ b/.design/presentation_export.md
@@ -1,13 +1,13 @@
 # Presentation Export & Slide Generation
 
-This document describes the architecture for converting intermediate slide representations ("Proto-slides") into final presentation formats. While currently implemented using `python-pptx`, the system is designed to be modular to support alternative export engines (like Pandoc or HTML-based decks).
+This document describes the architecture for converting intermediate slide representations ("Proto-slides") into final presentation formats. The active export engine is `PandocBuilder`, which converts a Pandoc Markdown representation of each slide (with native LaTeX math support) into a `.pptx` file. The original `python-pptx` implementation is retained in the codebase for archival purposes but is no longer invoked.
 
 ## The Generation Pipeline
 
 Slide generation is a two-phase process:
 
 1.  **Synthesis Phase**: The Multi-agent Graph (`src.graph`) analyzes research data and populates `wip.db` with `ProtoSlide` objects.
-2.  **Export Phase**: An export builder (e.g., `PptxBuilder`) reads the `wip.db` and renders the final file.
+2.  **Export Phase**: `PandocBuilder` reads `wip.db`, renders each slide as Pandoc Markdown, and converts the full deck to `.pptx` via the Pandoc binary (bundled with the `pypandoc_binary` wheel).
 
 ## Data Contract: Proto-Slides
 
@@ -19,16 +19,87 @@ The bridge between synthesis and export is the `ProtoSlide` schema defined in `s
     *   `layout`: A literal (e.g., `title_and_body`, `two_column`, `big_number`, `quote`) that hints at how the slide should be styled.
     *   `speaker_notes`: Narrative text for the presenter.
 *   **`BulletPoint`**:
-    *   `text`: The primary bullet text.
-    *   `sub_bullets`: A list of plain strings.
-    *   `bold_phrases`: Substrings within `text` that should be emphasized.
+    *   `text`: The primary bullet text. Supports Markdown formatting and LaTeX math (see [Markdown & LaTeX in Bullet Text](#markdown--latex-in-bullet-text) below).
+    *   `sub_bullets`: A list of plain strings (may also contain LaTeX math).
+    *   `bold_phrases`: Substrings within `text` that should be emphasized in bold.
     *   `content_type`: Semantic metadata (e.g., `statistic`, `insight`) for potential conditional styling.
 
-## Current Implementation: `PptxBuilder`
+## Active Implementation: `PandocBuilder`
 
-The default builder uses the `python-pptx` library to generate native PowerPoint files.
+**File**: `src/processing/export/pandoc_builder.py`  
+**Dependency**: `pypandoc_binary>=1.17` (Pandoc binary bundled in the wheel — no separate system install required)
+
+### How It Works
+
+`PandocBuilder._render_markdown(slides)` converts the ordered list of `ProtoSlide` objects into a single Pandoc Markdown string. Each slide block follows this structure:
+
+```markdown
+# Slide Title
+
+- Bullet one with **bold emphasis** and inline math $O(n^2)$
+  - Sub-bullet with supporting detail
+- Core result:
+  - $$\text{Attention}(Q,K,V) = \text{softmax}\!\left(\frac{QK^T}{\sqrt{d_k}}\right)V$$
+
+::: notes
+Speaker notes in a conversational tone...
+:::
+
+---
+```
+
+Key rendering details:
+
+| Element | Rendering |
+| :--- | :--- |
+| Slide title | Level-1 Markdown heading (`# Title`) |
+| Bullets | `-` list items |
+| Sub-bullets | Indented two spaces (`  - sub`) |
+| Bold emphasis | `bold_phrases` matched and wrapped as `**phrase**` |
+| Speaker notes | Pandoc fenced div (`::: notes` / `:::`) |
+| Slide separator | `---` horizontal rule |
+
+### Pandoc Conversion
+
+```python
+pypandoc.convert_text(
+    markdown,
+    "pptx",
+    format="markdown+tex_math_dollars",
+    outputfile=str(output_path),
+    extra_args=["--standalone"],
+)
+```
+
+The `tex_math_dollars` Markdown extension enables `$...$` (inline) and `$$...$$` (display) math parsing. Pandoc converts LaTeX math to **OMML** (Office Math Markup Language), which PowerPoint renders natively without any plugins.
+
+### Markdown & LaTeX in Bullet Text
+
+The `BulletPoint.text` field and `sub_bullets` strings support Markdown and LaTeX math. The slide generation agents (`research_to_slide`) are instructed to use these when presenting important equations:
+
+*   **Inline math** — for formulas referenced within a sentence:
+    ```
+    The model achieves $O(n^2)$ complexity with respect to sequence length.
+    ```
+*   **Display math** — for landmark equations; placed as the sole content of a `sub_bullet` so it renders on its own line:
+    ```
+    $$\text{Attention}(Q,K,V) = \text{softmax}\!\left(\frac{QK^T}{\sqrt{d_k}}\right)V$$
+    ```
+*   **Bold Markdown** — `**text**` may be used directly in `text` for emphasis alongside or instead of `bold_phrases`.
+
+Equations should only be included when they are central to the slide's `key_message` or represent a landmark result from the source material.
+
+---
+
+## Archival Implementation: `PptxBuilder`
+
+**File**: `src/processing/export/pptx_builder.py` *(not invoked — retained for reference)*  
+**Dependency**: `python-pptx>=1.0.0`
+
+This was the original export engine. It generates `.pptx` files directly using the `python-pptx` library with no intermediate Markdown step. It does not support LaTeX math rendering.
 
 ### Layout Mapping
+
 The builder maps the generic `layout` literals from `SlideContent` to specific indices or names in a PowerPoint template:
 
 | Literal | PPTX Layout Mapping | Special Behavior |
@@ -41,15 +112,17 @@ The builder maps the generic `layout` literals from `SlideContent` to specific i
 | `media_left` | "Two Content" | Reserves left side for `media_id` placement |
 
 ### Styling Logic
--   **Bold Emphasis**: The builder performs substring matching using `bold_phrases` to apply `run.font.bold = True` to specific segments of bullet text.
+
+-   **Bold Emphasis**: Performs substring matching using `bold_phrases` to apply `run.font.bold = True` to specific segments of bullet text.
 -   **Speaker Notes**: Content is written directly to the `notes_slide` of each generated slide.
 -   **Fallbacks**: If a template is missing a named layout, the builder falls back to "Title and Content" (Index 1) to prevent crashes.
 
+---
+
 ## Future Extensibility: The Abstract Builder
 
-To support the requirement of replacing `python-pptx` or adding new formats (like Pandoc-driven Markdown-to-PPTX), we utilize a Strategy pattern.
+To support additional export formats, a Strategy pattern can be used with a shared abstract interface:
 
-### Planned Interface
 ```python
 class PresentationBuilder(ABC):
     @abstractmethod
@@ -58,14 +131,24 @@ class PresentationBuilder(ABC):
         pass
 
     @abstractmethod
-    def _add_slide(self, prs: Any, proto: ProtoSlide) -> None:
-        """Internal logic to render a single proto-slide."""
+    def _render_markdown(self, slides: list) -> str:
+        """Internal logic to render all proto-slides into an intermediate format."""
         pass
 ```
 
-## Utilization for Developers
+Both `PandocBuilder` and the archival `PptxBuilder` conform to the `build()` contract. A new backend (e.g., an HTML/reveal.js exporter) would implement the same interface and be swapped in at the call site in `main.py`.
+
+## Developer Notes
 
 ### Adding New Layouts
+
+For `PandocBuilder`, layout literals in `SlideContent` are not directly mapped — Pandoc's default PPTX template is used. To apply custom slide layouts:
+
+1.  Provide a reference `.pptx` template via `--reference-doc=template.pptx` in `extra_args`.
+2.  Pandoc will use the layout from the reference doc whose name matches the slide level.
+
+For the archival `PptxBuilder`:
+
 1.  Update the `layout` Literal in `src.memory.wip.schema.SlideContent`.
-2.  Update the `_LAYOUT_MAP` in `PptxBuilder` to map that literal to a template layout.
-3.  Add any custom logic in `_set_body` or `_write_run` if the layout requires special styling (like the `big_number` mode).
+2.  Update `_LAYOUT_MAP` in `PptxBuilder` to map that literal to a template layout.
+3.  Add any custom logic in `_set_body` or `_write_run` if the layout requires special styling.

--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,6 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OLLAMA_API_KEY=your_ollama_key_here
 OLLAMA_BASE_URL=https://ollama.com
 GEMINI_API_KEY=your_key_here
-GEMINI_BASE_URL=https://generativelanguage.googleapis.com/
 ANTHROPIC_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
 LANGFUSE_SECRET_KEY=sk-lf-...

--- a/main.py
+++ b/main.py
@@ -250,18 +250,18 @@ def main() -> None:
 
 
     if args.slides:
-        from src.processing.export.pptx_builder import PptxBuilder
-        
+        from src.processing.export.pandoc_builder import PandocBuilder
+
         # Use paper title if available, fallback to doc_id or session_id
         raw_name = final_state.get('paper_title') or final_state.get('doc_id') or final_state['session_id']
         safe_name = _sanitize_filename(raw_name)
         if not safe_name:
             safe_name = final_state['session_id']
-            
+
         pptx_path = OUTPUT_DIR / f"{safe_name}.pptx"
         try:
             with WIPDatabase() as wip_db:
-                out = PptxBuilder(output_path=pptx_path, db=wip_db).build()
+                out = PandocBuilder(output_path=pptx_path, db=wip_db).build()
             print(f"\n[export] Presentation saved → {out}")
         except ValueError as exc:
             print(f"\n[export] Could not generate PPTX: {exc}")

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from typing import Any
 import time
 from pathlib import Path
 import os
+import re
 from src.memory import get_database
 from src.graph import build_graph
 from src.llm.llm import init_from_config
@@ -209,7 +210,6 @@ def _sanitize_filename(name: str) -> str:
     if not name:
         return ""
     # Replace invalid chars with underscore
-    import re
     safe = "".join(ch if ch.isalnum() or ch in (" ", "-", "_") else "_" for ch in name)
     # Collapse multiple underscores/spaces and switch spaces to underscores
     safe = re.sub(r"[ _]+", "_", safe).strip("_")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ llama-cloud
 semantic-text-splitter
 boto3>=1.34.0
 tenacity>=8.0.0
-python-pptx>=1.0.0
+pypandoc_binary>=1.17
 litellm>=1.0.0
 pyyaml>=6.0,<7.0

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -2,7 +2,7 @@ import json
 import typing
 from typing import TypeVar
 from pydantic import BaseModel, ValidationError
-from src.llm.llm import get_llm, _strip_think_block, _strip_code_fence, _heal_json
+from src.llm.llm import get_llm, _strip_think_block, _strip_code_fence, _heal_json, DEFAULT_MODEL_NAME
 from src.state import DeliveryPlan
 from src.logging.logger import AgentLogger
 
@@ -217,9 +217,11 @@ class BaseLLMAgent:
         if model is not None:
             override["model"] = model
         llm = get_llm(llm_config_override=override if override else None)
-        label = model or "default"
-        self._base_logger.log(f"[{self._log_display}] Invoking LLM (model: {label})")
-        return llm.complete(messages, schema=schema)
+        content = llm.complete(messages, schema=schema)
+        actual_model = llm.last_model_used or (model or DEFAULT_MODEL_NAME)
+        label = f"default ({actual_model})" if model is None else f"{model} ({actual_model})"
+        self._base_logger.log(f"[{self._log_display}] Invoked LLM (model: {label})")
+        return content
 
     def _call(
         self,

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -144,9 +144,8 @@ You are a Senior Presentation Designer and Research Synthesizer. Your goal is to
 - **`key_message`**: Write one crisp sentence stating what the audience should understand after this slide. This is the thesis — not a summary of bullet points.
 - **`title`**: Use punchy, "active" headings (e.g., "Accuracy Jumps 40%" not "Accuracy Results").
 - **`bullets`**: Produce 3-5 `BulletPoint` objects. Each object MUST use these exact field names:
-  - `"text"` — the bullet content string. IMPORTANT: the field is called `"text"`, NOT `"content"`.
+  - `"text"` — the bullet content string. IMPORTANT: the field is called `"text"`, NOT `"content"`. Use `**phrase**` to bold 0–2 key terms or statistics per bullet (e.g., `"Accuracy improves by **47%** over the baseline"`). Only bold genuinely critical terms — not decorative emphasis.
   - `"content_type"` — exactly one of: `"insight"`, `"evidence"`, `"statistic"`, `"example"`, `"caveat"`.
-  - `"bold_phrases"` — a flat list of exact substrings from `"text"` that should appear in bold (e.g., `["47%", "record high"]`). Use 0–2 phrases per bullet and only for genuinely critical terms or statistics. Omit or leave empty if nothing warrants emphasis.
   - `"sub_bullets"` — a flat list of plain strings for supporting detail that expands on the main point without cluttering the top level (NOT objects).
 - **`speaker_notes`**: Write this section in a professional, conversational tone. Include context, nuance, and supporting evidence too detailed for the slide body.  Include something for each bullet point.
 
@@ -154,6 +153,14 @@ You are a Senior Presentation Designer and Research Synthesizer. Your goal is to
 - Respect the slide capacity strictly.
 - All information must be strictly grounded in the provided research chunks.
 - Avoid academic jargon unless the terminology is important/prominent and should be emphasized.
+
+### MARKDOWN & EQUATIONS:
+- Bullet `text` fields support Markdown formatting and LaTeX math.
+- Use LaTeX for important equations:
+  - Inline (within a sentence): `$E = mc^2$` or `$O(n^2)$`
+  - Display (standalone, prominent): `$$\\text{Attention}(Q,K,V) = \\text{softmax}\\!\\left(\\frac{QK^T}{\\sqrt{d_k}}\\right)V$$`
+- Place display equations as the sole content of a `sub_bullet` so they render on their own line.
+- Include an equation only when it is central to the slide's `key_message` or represents a landmark result from the research.
 """
 
 AGENT_ROLES = {

--- a/src/agents/parse_supervisor.py
+++ b/src/agents/parse_supervisor.py
@@ -251,7 +251,7 @@ class ParseSupervisorAgent(BaseLLMAgent):
             f"into parallel agent assignments with a total slide budget of {max_slides}."
         )
         turns = [{"role": "user", "content": user_msg}]
-        return self._call(turns, schema=PartitionPlan)
+        return self._call(turns, schema=PartitionPlan, model="slides")
 
     # ------------------------------------------------------------------
     # Step 5 — Plan repair

--- a/src/agents/research_to_slide.py
+++ b/src/agents/research_to_slide.py
@@ -87,7 +87,7 @@ class ResearchToSlideAgent(BaseLLMAgent):
         
         # 2. Invoke LLM
         output_schema = SlideGenerationOutput
-        result: SlideGenerationOutput = self._call(turns, schema=output_schema)
+        result: SlideGenerationOutput = self._call(turns, schema=output_schema, model="slides")
 
         # 3. Save to wip.db
         wip_db = WIPDatabase()

--- a/src/llm/config.yaml
+++ b/src/llm/config.yaml
@@ -20,8 +20,9 @@ router:
   providers:
     gemini:
       api_key: "os.environ/GEMINI_API_KEY"
-      api_base: "os.environ/GEMINI_BASE_URL"
       models:
+        - model: "gemini/gemini-3.1-flash-lite-preview"
+          model_name: "slides"
         - model: "gemini/gemini-2.5-pro"
         - model: "gemini/gemini-2.5-flash"
         - model: "gemini/gemini-2.5-flash-lite"

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -179,6 +179,7 @@ class LiteLLMProvider:
         if ROUTER is None:
             init_from_config()
         self._router = ROUTER
+        self.last_model_used: str | None = None
 
     def complete(
         self,
@@ -204,6 +205,7 @@ class LiteLLMProvider:
             kw["response_format"] = {"type": "json_object"}
 
         resp = self._router.completion(**kw)
+        self.last_model_used = getattr(resp, "model", None) or kw["model"]
         return resp.choices[0].message.content or ""
 
 

--- a/src/memory/wip/schema.py
+++ b/src/memory/wip/schema.py
@@ -7,16 +7,16 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 class BulletPoint(BaseModel):
     text: str = Field(
-        description='The bullet point text. Field name is "text" — do NOT use "content".',
+        description=(
+            'The bullet point text. Supports Markdown formatting and LaTeX math '
+            '(e.g., inline `$E=mc^2$` or display `$$\\frac{a}{b}$$`). '
+            'Field name is "text" — do NOT use "content".'
+        ),
         validation_alias=AliasChoices("text", "content"),
     )
     sub_bullets: List[str] = Field(
         default_factory=list,
         description='Optional sub-bullet points as plain strings (NOT objects). Example: ["Detail A", "Detail B"]',
-    )
-    bold_phrases: List[str] = Field(
-        default_factory=list,
-        description='Exact substrings from `text` that should be rendered in bold. Use 0–2 per bullet. Example: ["47%", "record high"]',
     )
     content_type: Literal["insight", "evidence", "statistic", "example", "caveat"] = Field(default="insight", description="Semantic type of this bullet point")
 
@@ -30,19 +30,6 @@ class BulletPoint(BaseModel):
             if isinstance(item, dict)
             else str(item)
             for item in v
-        ]
-
-    @field_validator("bold_phrases", mode="before")
-    @classmethod
-    def coerce_bold_phrases(cls, v: object) -> list[str]:
-        if not isinstance(v, list):
-            return []
-        return [
-            (item.get("text") or item.get("content") or str(item))
-            if isinstance(item, dict)
-            else str(item)
-            for item in v
-            if item
         ]
 
 

--- a/src/processing/export/pandoc_builder.py
+++ b/src/processing/export/pandoc_builder.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import List
+
+import pypandoc
+
+from src.memory.wip.database import WIPDatabase
+from src.memory.wip.schema import BulletPoint, ProtoSlide, SlideContent
+
+
+def _render_bullet(bullet: BulletPoint) -> List[str]:
+    """Returns a list of Markdown lines for a single BulletPoint."""
+    lines = [f"- {bullet.text}"]
+    for sub in bullet.sub_bullets:
+        lines.append(f"  - {sub}")
+    return lines
+
+
+def _render_slide(proto: ProtoSlide) -> str:
+    """Converts a single ProtoSlide into a Pandoc Markdown slide block."""
+    content: SlideContent = proto.content
+    parts: List[str] = []
+
+    parts.append(f"# {content.title}")
+    parts.append("")
+
+    for bullet in content.bullets:
+        parts.extend(_render_bullet(bullet))
+
+    if content.speaker_notes:
+        parts.append("")
+        parts.append("::: notes")
+        parts.append(content.speaker_notes)
+        parts.append(":::")
+
+    return "\n".join(parts)
+
+
+class PandocBuilder:
+    """
+    Reads all ProtoSlide rows from a WIPDatabase, renders them as Pandoc
+    Markdown (with LaTeX math support via the tex_math_dollars extension),
+    and converts the result to a .pptx file using pypandoc.
+
+    Bullet text may contain Markdown formatting and LaTeX math:
+      - Inline math:  $E = mc^2$
+      - Display math: $$\\text{Attention}(Q,K,V) = \\text{softmax}(...)V$$
+
+    Pandoc converts LaTeX math to OMML, which PowerPoint renders natively.
+
+    Usage::
+
+        with WIPDatabase() as db:
+            PandocBuilder(output_path=Path("output.pptx"), db=db).build()
+    """
+
+    _PANDOC_FORMAT = "markdown+tex_math_dollars"
+
+    def __init__(self, output_path: Path, db: WIPDatabase) -> None:
+        self.output_path = Path(output_path)
+        self._db = db
+
+    def build(self) -> Path:
+        """
+        Loads all proto-slides from wip.db in slide-number order, renders them
+        to Pandoc Markdown, and writes the presentation to self.output_path.
+        Returns the resolved path.
+
+        Raises:
+            ValueError: if no slides exist in the database.
+        """
+        slide_numbers = self._db.list_slide_numbers()
+        if not slide_numbers:
+            raise ValueError(
+                "PandocBuilder: no proto-slides found in wip.db. "
+                "Run the slide-generation graph first."
+            )
+
+        slides: List[ProtoSlide] = [
+            self._db.load_slide(n) for n in slide_numbers
+        ]
+        slides = [s for s in slides if s is not None]
+
+        markdown = self._render_markdown(slides)
+
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        pypandoc.convert_text(
+            markdown,
+            "pptx",
+            format=self._PANDOC_FORMAT,
+            outputfile=str(self.output_path),
+            extra_args=["--standalone"],
+        )
+
+        return self.output_path.resolve()
+
+    def _render_markdown(self, slides: List[ProtoSlide]) -> str:
+        """Renders the full deck as a Pandoc Markdown string."""
+        blocks = [_render_slide(s) for s in slides]
+        return "\n\n---\n\n".join(blocks)

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,5 @@
 # Available models for reference:
-# - gemini-2.5-flash-lite
+# - gemini-3.1-flash-lite-preview
 # - qwen3.5:397b
 # - meta-llama/llama-3.2-3b-instruct
 # - meta-llama/llama-3.3-70b-instruct


### PR DESCRIPTION
Made slide pipeline use gemini3.1 flash lite preview (much superior, 500 RPD vs 20 RPD for 2.5 flash lite, also much faster than ollama and openrouter models and less validation errors)
Removed gemini_url in .env.sample (litellm does not need to override gemini url with an env variable unless using proxy)
Changed litellmprovidor to store lastmodelused for logging
Fully working pandoc conversion to pptx (much superior to python-pptx)
Replaced python-pptx with pypandoc_binary in requirements.txt
Updated slide agent prompts to allow markdown/latex in bullet points in proto-slides
Removed bold_phrases functionality
In main.py, put import re at the top