### PR TITLE
Less clutter validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ artifacts/
 extracted_viewer/
 data/
 output/
+validation_errors/

--- a/README.md
+++ b/README.md
@@ -136,3 +136,15 @@ The system implements a dual-layer observability strategy to maintain clean agen
 
 - **Workflow Tracing**: Captures the high-level orchestration, state transitions, and routing overhead as the research document flows between the specialized agents.
 - **Cognitive Tracing**: Instruments the underlying LLM calls to capture precise generation metrics (latency, token usage) and raw prompt details completely independently of the graph execution.
+
+### Validation Error Dumps
+
+When an LLM response fails Pydantic schema validation, the full error detail and offending JSON are written to a structured dump file under `validation_errors/` rather than flooding the terminal. The terminal log shows only a succinct one-liner with a path to the relevant file.
+
+The `validation_errors/` folder is cleared automatically at the start of every `main.py` run, so it always reflects the most recent execution. The folder is gitignored and will not appear in version control. If any validation errors occurred during a run, a summary line is printed at the end of the run:
+
+```
+[validation] 3 error dump(s) written to validation_errors/
+```
+
+Each dump file is a JSON object containing the agent name, attempt number, timestamp, error summary, and the raw offending JSON for inspection.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import shutil
 import sys
 from typing import Any
 import time
@@ -13,7 +14,7 @@ from src.processing.document import DocProcessor
 from src.processing.embedder.provider import get_text_embedder
 import uuid
 from datetime import datetime, timezone
-from src.logging.logger import AgentLogger
+from src.logging.logger import AgentLogger, VALIDATION_ERRORS_DIR
 from src.memory.wip.database import WIPDatabase
 from src.memory.objectstore import LocalObjectStore, R2ObjectStore, DEFAULT_OBJECT_STORE_CONFIG
 
@@ -219,6 +220,11 @@ def main() -> None:
     args = _parse_args()
     logger = AgentLogger()
 
+    # Clear validation error dumps from the previous run
+    if VALIDATION_ERRORS_DIR.exists():
+        shutil.rmtree(VALIDATION_ERRORS_DIR)
+    VALIDATION_ERRORS_DIR.mkdir(exist_ok=True)
+
     # Reset WIP database for the new run
     with WIPDatabase() as db:
         db.reset()
@@ -243,6 +249,10 @@ def main() -> None:
     except Exception as e:
         print(f"\n[!] Research Graph encountered an error mid-flight: {e}")
         print("    Attempting to recover partial logs...")
+
+    ve_files = list(VALIDATION_ERRORS_DIR.glob("*.json"))
+    if ve_files:
+        print(f"\n[validation] {len(ve_files)} error dump(s) written to {VALIDATION_ERRORS_DIR}/")
 
     print("\n--- Agent Log ---")
     for msg in final_state.get("messages", []):

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -2,7 +2,7 @@ import json
 import typing
 from typing import TypeVar
 from pydantic import BaseModel, ValidationError
-from src.llm.llm import get_llm, _strip_think_block, _strip_code_fence, _heal_json, DEFAULT_MODEL_NAME
+from src.llm.llm import get_llm, _strip_think_block, _strip_code_fence, _heal_json, DEFAULT_MODEL_NAME, LLMCallError, current_agent_label
 from src.state import DeliveryPlan
 from src.logging.logger import AgentLogger
 
@@ -178,6 +178,7 @@ class BaseLLMAgent:
         self.role = role
         self._log_display = log_display if log_display is not None else role
         self._base_logger = AgentLogger()
+        self._last_model_used: str | None = None  # Used for logging validation errors
 
     def _build_messages(self, turns: list[dict]) -> list[dict]:
         """Build the full message list by prepending the system prompt.
@@ -224,11 +225,26 @@ class BaseLLMAgent:
         if model is not None:
             override["model"] = model
         llm = get_llm(llm_config_override=override if override else None)
-        content = llm.complete(messages, schema=schema)
-        actual_model = llm.last_model_used or (model or DEFAULT_MODEL_NAME)
-        label = f"default ({actual_model})" if model is None else f"{model} ({actual_model})"
-        self._base_logger.log(f"[{self._log_display}] Invoked LLM (model: {label})")
-        return content
+        token = current_agent_label.set(self._log_display)
+        try:
+            try:
+                content = llm.complete(messages, schema=schema)
+            except LLMCallError as exc:
+                model_label = (
+                    f"{exc.model} ({exc.actual_model})" if exc.actual_model else exc.model
+                )
+                self._base_logger.log(
+                    f"[{self._log_display}] LLM call failed (model={model_label}): {exc}",
+                    level="error",
+                )
+                raise
+            actual_model = llm.last_model_used or (model or DEFAULT_MODEL_NAME)
+            self._last_model_used = actual_model
+            label = f"default ({actual_model})" if model is None else f"{model} ({actual_model})"
+            self._base_logger.log(f"[{self._log_display}] Invoked LLM (model: {label})")
+            return content
+        finally:
+            current_agent_label.reset(token)
 
     def _call(
         self,
@@ -270,10 +286,14 @@ class BaseLLMAgent:
                     if attempt < max_retries
                     else " No retries left; propagating error."
                 )
+                dump_path = self._base_logger.dump_validation_error(
+                    self._log_display, attempt, max_retries + 1, e, clean,
+                    model=self._last_model_used,
+                )
+                location = f" See: {dump_path}" if dump_path else ""
                 self._base_logger.log(
                     f"[{self._log_display}] Validation error "
-                    f"(attempt {attempt + 1}/{max_retries + 1}).{retry_note}\n"
-                    f"{e}\n\nOffending JSON:\n{clean}"
+                    f"(attempt {attempt + 1}/{max_retries + 1}).{retry_note}{location}"
                 )
                 if attempt == max_retries:
                     break

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,5 +1,4 @@
 import json
-import typing
 from typing import TypeVar
 from pydantic import BaseModel, ValidationError
 from src.llm.llm import get_llm, _strip_think_block, _strip_code_fence, _heal_json, DEFAULT_MODEL_NAME, LLMCallError, current_agent_label
@@ -177,7 +176,7 @@ class BaseLLMAgent:
     def __init__(self, role: str, *, log_display: str | None = None):
         self.role = role
         self._log_display = log_display if log_display is not None else role
-        self._base_logger = AgentLogger()
+        self._logger = AgentLogger()
         self._last_model_used: str | None = None  # Used for logging validation errors
 
     def _build_messages(self, turns: list[dict]) -> list[dict]:
@@ -227,24 +226,23 @@ class BaseLLMAgent:
         llm = get_llm(llm_config_override=override if override else None)
         token = current_agent_label.set(self._log_display)
         try:
-            try:
-                content = llm.complete(messages, schema=schema)
-            except LLMCallError as exc:
-                model_label = (
-                    f"{exc.model} ({exc.actual_model})" if exc.actual_model else exc.model
-                )
-                self._base_logger.log(
-                    f"[{self._log_display}] LLM call failed (model={model_label}): {exc}",
-                    level="error",
-                )
-                raise
-            actual_model = llm.last_model_used or (model or DEFAULT_MODEL_NAME)
-            self._last_model_used = actual_model
-            label = f"default ({actual_model})" if model is None else f"{model} ({actual_model})"
-            self._base_logger.log(f"[{self._log_display}] Invoked LLM (model: {label})")
-            return content
+            content = llm.complete(messages, schema=schema)
+        except LLMCallError as exc:
+            model_label = (
+                f"{exc.model} ({exc.actual_model})" if exc.actual_model else exc.model
+            )
+            self._logger.log(
+                f"[{self._log_display}] LLM call failed (model={model_label}): {exc}",
+                level="error",
+            )
+            raise
         finally:
             current_agent_label.reset(token)
+        actual_model = llm.last_model_used or (model or DEFAULT_MODEL_NAME)
+        self._last_model_used = actual_model
+        label = f"default ({actual_model})" if model is None else f"{model} ({actual_model})"
+        self._logger.log(f"[{self._log_display}] Invoked LLM (model: {label})")
+        return content
 
     def _call(
         self,
@@ -286,12 +284,12 @@ class BaseLLMAgent:
                     if attempt < max_retries
                     else " No retries left; propagating error."
                 )
-                dump_path = self._base_logger.dump_validation_error(
+                dump_path = self._logger.dump_validation_error(
                     self._log_display, attempt, max_retries + 1, e, clean,
                     model=self._last_model_used,
                 )
                 location = f" See: {dump_path}" if dump_path else ""
-                self._base_logger.log(
+                self._logger.log(
                     f"[{self._log_display}] Validation error "
                     f"(attempt {attempt + 1}/{max_retries + 1}).{retry_note}{location}"
                 )

--- a/src/agents/parse_supervisor.py
+++ b/src/agents/parse_supervisor.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel, Field
 from src.state import ResearchState
 from src.agents.base import BaseLLMAgent
 from src.memory.research.database import ResearchDatabase
-from src.logging.logger import AgentLogger
 
 # ---------------------------------------------------------------------------
 # Heading detection (LlamaParse produces standard ATX markdown headings)
@@ -101,7 +100,6 @@ class ParseSupervisorAgent(BaseLLMAgent):
 
     def __init__(self) -> None:
         super().__init__("parse_supervisor")
-        self._logger = AgentLogger()
 
     # ------------------------------------------------------------------
     # Public entry point — called by the graph node

--- a/src/agents/research_to_slide.py
+++ b/src/agents/research_to_slide.py
@@ -6,7 +6,6 @@ from src.agents.base import BaseLLMAgent
 from src.memory.wip.schema import ProtoSlide, SlideContent
 from src.memory.research.database import ResearchDatabase
 from src.memory.wip.database import WIPDatabase
-from src.logging.logger import AgentLogger
 
 class SlideGenerationOutput(BaseModel):
     slides: List[SlideContent] = Field(description="The parsed slides synthesized from the text chunks")
@@ -27,7 +26,6 @@ def _slide_range_log_label(state: DispatchState) -> str:
 class ResearchToSlideAgent(BaseLLMAgent):
     def __init__(self, *, log_display: str | None = None):
         super().__init__("research_to_slide", log_display=log_display)
-        self._logger = AgentLogger()
 
     def run(self, state: DispatchState) -> Command:
         chunk_ids = state.get("chunk_ids", [])

--- a/src/llm/config.yaml
+++ b/src/llm/config.yaml
@@ -14,6 +14,7 @@ router:
   fallback_model_name: "fallback"
   fallbacks:
     - app: ["fallback"]
+    - slides: ["fallback"]
     # - writer: ["fallback"]
     # - fast: ["fallback"]
 
@@ -23,23 +24,38 @@ router:
       models:
         - model: "gemini/gemini-3.1-flash-lite-preview"
           model_name: "slides"
-        - model: "gemini/gemini-2.5-pro"
         - model: "gemini/gemini-2.5-flash"
+          model_name: "slides"
         - model: "gemini/gemini-2.5-flash-lite"
+          model_name: "slides"
+        - model: "gemini/gemini-2.5-pro"
 
+  # Note: splitting fallback_providers into *_high and *_rest allows us to control the 
+  # exact model-level fallback order across different providers (e.g. OpenRouter -> Ollama -> OpenRouter)
+  # since the Router follows the order entries appear in this YAML.
   fallback_providers:
-    openrouter:
+    openrouter_high:
       api_key: "os.environ/OPENROUTER_API_KEY"
       api_base: "os.environ/OPENROUTER_BASE_URL"
       models:
         - model: "openrouter/openai/gpt-oss-120b:free"
-        - model: "openrouter/openai/gpt-oss-20b:free"
 
-    ollama:
+    ollama_high:
       api_key: "os.environ/OLLAMA_API_KEY"
       api_base: "os.environ/OLLAMA_BASE_URL"
       models:
         - model: "ollama/qwen3.5:397b-cloud"
+
+    openrouter_rest:
+      api_key: "os.environ/OPENROUTER_API_KEY"
+      api_base: "os.environ/OPENROUTER_BASE_URL"
+      models:
+        - model: "openrouter/openai/gpt-oss-20b:free"
+
+    ollama_rest:
+      api_key: "os.environ/OLLAMA_API_KEY"
+      api_base: "os.environ/OLLAMA_BASE_URL"
+      models:
         - model: "ollama/gemma3:27b-cloud"
 
   settings:

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -46,7 +46,7 @@ class _FailureLogger(CustomLogger):
         return f"[{agent}] Deployment failed: {model} — {exc_type}{status_part}: {msg}"
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
-        _agent_logger.warning(self._format(kwargs))
+        _agent_logger.log(self._format(kwargs), level="warning")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
         _agent_logger.warning(self._format(kwargs))

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import json
 import re
 from dataclasses import dataclass, field
@@ -9,8 +10,12 @@ import yaml
 from dotenv import load_dotenv
 from pydantic import BaseModel
 import litellm
+import logging as _logging
+_logging.getLogger("LiteLLM").setLevel(_logging.ERROR)
+_logging.getLogger("LiteLLM Router").setLevel(_logging.ERROR)
 from litellm.router import Router
 from litellm.types.router import DeploymentTypedDict
+from litellm.integrations.custom_logger import CustomLogger
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -18,8 +23,36 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
 load_dotenv(dotenv_path=str(_PROJECT_ROOT / ".env"))
 
-litellm.success_callback = ["langfuse"]
-litellm.failure_callback = ["langfuse"]
+_agent_logger = _logging.getLogger("agentic_ai")
+current_agent_label: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "current_agent_label", default="LLM",
+)
+
+
+class _FailureLogger(CustomLogger):
+    """Logs every individual LiteLLM deployment failure as a clean one-liner."""
+
+    def _format(self, kwargs: dict) -> str:
+        agent = current_agent_label.get()
+        model = kwargs.get("model") or "unknown"
+        exc = kwargs.get("exception")
+        exc_type = type(exc).__name__ if exc else "Error"
+        status = getattr(exc, "status_code", None)
+        status_part = f" [{status}]" if status else ""
+        msg = str(exc) if exc else ""
+        # Trim the message to the first sentence / newline to keep it short
+        msg = msg.split("\n")[0][:120]
+        return f"[{agent}] Deployment failed: {model} — {exc_type}{status_part}: {msg}"
+
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
+        _agent_logger.warning(self._format(kwargs))
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
+        _agent_logger.warning(self._format(kwargs))
+
+
+_failure_logger = _FailureLogger()
+litellm.callbacks = [_failure_logger, "langfuse"]
 
 ROUTER: Router | None = None
 DEFAULT_MODEL_NAME: str = "app"
@@ -35,6 +68,18 @@ class LLMConfig:
     litellm_params: dict | None = field(default_factory=dict)
 
 GLOBAL_CONFIG = LLMConfig()
+
+
+class LLMCallError(RuntimeError):
+    """Raised when the LiteLLM router exhausts all retries/fallbacks."""
+    def __init__(self, model: str, cause: Exception) -> None:
+        self.model = model                                               # router alias, e.g. "slides"
+        self.actual_model: str | None = getattr(cause, "model", None)  # e.g. "gemini/gemini-3.1-flash-lite-preview"
+        self.status_code: int | None = getattr(cause, "status_code", None)
+        exc_type = type(cause).__name__
+        status_part = f" [{self.status_code}]" if self.status_code else ""
+        super().__init__(f"{exc_type}{status_part}")
+
 
 def build_litellm_model_list(
     config: dict[str, Any],
@@ -204,7 +249,10 @@ class LiteLLMProvider:
         if schema is not None:
             kw["response_format"] = {"type": "json_object"}
 
-        resp = self._router.completion(**kw)
+        try:
+            resp = self._router.completion(**kw)
+        except Exception as exc:
+            raise LLMCallError(kw["model"], exc) from None
         self.last_model_used = getattr(resp, "model", None) or kw["model"]
         return resp.choices[0].message.content or ""
 

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -16,6 +16,7 @@ _logging.getLogger("LiteLLM Router").setLevel(_logging.ERROR)
 from litellm.router import Router
 from litellm.types.router import DeploymentTypedDict
 from litellm.integrations.custom_logger import CustomLogger
+from src.logging.logger import AgentLogger
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -23,7 +24,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
 load_dotenv(dotenv_path=str(_PROJECT_ROOT / ".env"))
 
-_agent_logger = _logging.getLogger("agentic_ai")
+_agent_logger = AgentLogger()._logger
 current_agent_label: contextvars.ContextVar[str] = contextvars.ContextVar(
     "current_agent_label", default="LLM",
 )

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -24,7 +24,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
 load_dotenv(dotenv_path=str(_PROJECT_ROOT / ".env"))
 
-_agent_logger = AgentLogger()._logger
+_agent_logger = AgentLogger()
 current_agent_label: contextvars.ContextVar[str] = contextvars.ContextVar(
     "current_agent_label", default="LLM",
 )

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -49,7 +49,7 @@ class _FailureLogger(CustomLogger):
         _agent_logger.log(self._format(kwargs), level="warning")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
-        _agent_logger.warning(self._format(kwargs))
+        _agent_logger.log(self._format(kwargs), level="warning")
 
 
 _failure_logger = _FailureLogger()

--- a/src/logging/logger.py
+++ b/src/logging/logger.py
@@ -13,8 +13,21 @@ class AgentLogger:
     """
     AgentLogger handles integration with Langfuse to provide observability 
     for the multi-agent graph and LLM responses natively.
+
+    Implemented as a singleton so that repeated ``AgentLogger()`` calls across
+    agents and modules share a single Langfuse client and Python logger instance.
     """
+    _instance: "AgentLogger | None" = None
+
+    def __new__(cls) -> "AgentLogger":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self):
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
         # Langfuse automatically grabs LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, 
         # and LANGFUSE_BASE_URL from environment variables.
         self.client = Langfuse()

--- a/src/logging/logger.py
+++ b/src/logging/logger.py
@@ -1,11 +1,13 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
+
+VALIDATION_ERRORS_DIR = Path(__file__).parent.parent.parent / "validation_errors"
 
 class AgentLogger:
     """
@@ -76,6 +78,40 @@ class AgentLogger:
             with output_path.open("w", encoding="utf-8") as f:
                 json.dump(payload, f, ensure_ascii=False, indent=2, default=str)
             return str(output_path)
+        except Exception:
+            return None
+
+    def dump_validation_error(
+        self,
+        agent_display_name: str,
+        attempt: int,
+        max_attempts: int,
+        validation_error: Exception,
+        offending_json: str,
+        model: str | None = None,
+    ) -> Path | None:
+        """Write a structured validation-error dump to VALIDATION_ERRORS_DIR.
+
+        Returns the Path of the written file, or None on failure.
+        """
+        try:
+            VALIDATION_ERRORS_DIR.mkdir(parents=True, exist_ok=True)
+            safe_agent = self._sanitize_file_part(agent_display_name) or "agent"
+            ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+            filename = f"{safe_agent}_{attempt + 1}of{max_attempts}_{ts}.json"
+            out_path = VALIDATION_ERRORS_DIR / filename
+            payload = {
+                "agent": agent_display_name,
+                "model": model,
+                "attempt": attempt + 1,
+                "max_attempts": max_attempts,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "error_summary": str(validation_error),
+                "offending_json": offending_json,
+            }
+            with out_path.open("w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+            return out_path
         except Exception:
             return None
 


### PR DESCRIPTION
Validation error dumps to file, changed model priority for slides, made llm call failures visible and succint
Refactored AgentLogger so it only instantiates once, cleaner code, only 1 langfuse connection (reused) instead of 8 separate ones