### PR TITLE
Presigned URL for R2 Clients

### DIFF
--- a/src/memory/objectstore/image_uploader.py
+++ b/src/memory/objectstore/image_uploader.py
@@ -1,0 +1,87 @@
+"""Utility for uploading base64 images to R2 and getting public URLs."""
+
+import hashlib
+from base64 import b64decode
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.memory.objectstore.provider import ObjectStoreProvider
+
+class ImageUploader:
+    """Upload base64 images to R2 and return public URLs."""
+
+    def __init__(self, object_store: "ObjectStoreProvider"):
+        self.object_store = object_store
+        self._upload_cache: dict[str, str] = {}
+
+    def get_or_upload_url(self, doc_id: str, image_id: str, base64_data: str) -> str:
+        """
+        Get R2 URL for image, uploading if necessary.
+
+        Args:
+            doc_id: Document identifier
+            image_id: Image identifier
+            base64_data: Base64 encoded image data
+
+        Returns:
+            Public URL for multimodal LLM input
+        """
+        # Create cache key from base64 data
+        cache_key = hashlib.md5(base64_data.encode()).hexdigest()
+
+        # Check cache first
+        if cache_key in self._upload_cache:
+            return self._upload_cache[cache_key]
+
+        try:
+            # Decode base64 data
+            image_bytes = b64decode(base64_data)
+
+            # Determine file extension from the data
+            # First 10 bytes should contain magic number for image format
+            ext = self._guess_image_extension(image_bytes[:12])
+            if not ext:
+                ext = "png"  # default fallback
+
+            # Upload to R2 with proper key
+            storage_key = f"{doc_id}/images/{image_id}.{ext}"
+            public_url = self.object_store.write(storage_key, image_bytes)
+
+            # If the object store is R2, generate a presigned URL to avoid 401 errors
+            # Check if the object store has the generate_presigned_url method
+            if hasattr(self.object_store, 'generate_presigned_url'):
+                try:
+                    presigned_url = self.object_store.generate_presigned_url(storage_key)
+                    public_url = presigned_url
+                except Exception as e:
+                    # If generating presigned URL fails, continue with the original public URL
+                    print(f"[ImageUploader] Failed to generate presigned URL for {image_id}: {e}")
+
+            # Cache the result
+            self._upload_cache[cache_key] = public_url
+            return public_url
+
+        except Exception as e:
+            # Log error but don't fail the entire pipeline
+            print(f"[ImageUploader] Failed to upload image {image_id}: {e}")
+            # Return empty string to indicate failure
+            return ""
+
+    def _guess_image_extension(self, header_bytes: bytes) -> str | None:
+        """Guess image extension from file header bytes."""
+        # PNG signature
+        if header_bytes.startswith(b'\x89PNG\r\n\x1a\n'):
+            return "png"
+        # JPEG signature
+        elif header_bytes.startswith(b'\xff\xd8\xff'):
+            return "jpg"
+        # GIF signature
+        elif header_bytes.startswith(b'GIF87a') or header_bytes.startswith(b'GIF89a'):
+            return "gif"
+        # WebP signature
+        elif header_bytes.startswith(b'RIFF') and b'WEBP' in header_bytes:
+            return "webp"
+        # BMP signature
+        elif header_bytes.startswith(b'BM'):
+            return "bmp"
+        return None

--- a/src/memory/objectstore/r2_store.py
+++ b/src/memory/objectstore/r2_store.py
@@ -101,6 +101,32 @@ class R2ObjectStore(ObjectStoreProvider):
             self._logger.log(f"R2 upload failed: missing credentials for key '{key}'", level="error")
             raise
 
+    def generate_presigned_url(self, key: str, expiration: int = 3600) -> str:
+        """
+        Generate a presigned URL to share an R2 object.
+
+        Args:
+            key: Object key.
+            expiration: Time in seconds for the presigned URL to remain valid. Default is 1 hour.
+
+        Returns:
+            Presigned URL as a string.
+        """
+        try:
+            url = self._client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": self._bucket_name, "Key": key},
+                ExpiresIn=expiration,
+            )
+            self._logger.log(f"Generated presigned URL for {key}", level="info")
+            return url
+        except ClientError as e:
+            self._logger.log(f"Failed to generate presigned URL for {key}: {e}", level="error")
+            raise
+        except NoCredentialsError:
+            self._logger.log(f"Presigned URL generation failed: missing credentials for key '{key}'", level="error")
+            raise
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
@@ -126,7 +152,11 @@ class R2ObjectStore(ObjectStoreProvider):
         if key.startswith("http"):
             parsed = urlparse(key)
             # R2 public URL format: https://pub-{bucket}.r2.dev/{key}
-            object_key = parsed.path.lstrip("/")
+            # We need to handle both public and presigned URLs potentially
+            if "r2.cloudflarestorage.com" in parsed.netloc: # For non-public R2 URLs
+                object_key = "/".join(parsed.path.split("/")[2:]) # This will depend on the exact URL structure
+            else: # For pub-bucket.r2.dev URLs
+                object_key = parsed.path.lstrip("/")
 
         try:
             response = self._client.get_object(


### PR DESCRIPTION
Sometimes we run into error when fetching images from our Cloudflare R2 url becasue it was not a public bucket, so we need a presigned-url to get that

Also, created a logic where if we fail to retrieve a R2 image but that image exist locally, we upload that to R2 to prevent data loss