### PR TITLE
Refactor/images from ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/
 output/
 validation_errors/
 scratch/
+tests/

--- a/main.py
+++ b/main.py
@@ -373,7 +373,16 @@ def main() -> None:
             plan_title = presentation_plan.title
             plan_subtitle = getattr(presentation_plan, "subtitle", "") or ""
         safe_name = _sanitize_filename(raw_name) or session_id
-        pptx_path = output_dir / f"{safe_name}.pptx"
+
+        # Determine the prefix based on existing .pptx files in the output directory
+        if not output_dir.exists():
+            output_dir.mkdir(parents=True, exist_ok=True)
+            pptx_count = 0
+        else:
+            pptx_count = len(list(output_dir.glob("*.pptx")))
+
+        prefix = f"{pptx_count + 1} - "
+        pptx_path = output_dir / f"{prefix}{safe_name}.pptx"
         if final_state.get("review", {}).get("export_ready"):
             try:
                 out = PandocBuilder(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sqlite-vec>=0.1.0
 langfuse>=2.0,<3.0
 langchain>=0.2,<1.0
 sentence-transformers>=3.0,<4.0
-llama-cloud
+llama-cloud>=2.3.0,<3.0
 semantic-text-splitter
 boto3>=1.34.0
 tenacity>=8.0.0

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -11,6 +11,7 @@
 #
 # Current sample assumes free teir for Gemini, Ollama and OpenRouter.
 # Get available OpenRouter free models at https://openrouter.ai/collections/free-models (changes frequently).
+# See also https://github.com/mnfst/awesome-free-llm-apis (model lists likely outdated).  LiteLLM implements most of those.
 # A free OpenRouter account only gets 50 daily requests, adding minimum of 10 credits "verifies" your account and raises the daily limit to 1000 requests
 
 router:

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -1,6 +1,7 @@
 # Router group aliases: optional per-model-row ``model_name`` assigns a deployment to an alias
 # (default for ``providers`` is ``default_model_name``; for ``fallback_providers`` it is
 # ``fallback_model_name``). Use ``_call(..., model="writer")`` etc. to target an alias.
+# All models under ``fallback_providers`` without a ``model_name`` are implicitly considered "fallback" models.
 #
 # Example (commented):
 #   models:
@@ -20,11 +21,7 @@ router:
   fallbacks:
     - app: ["fallback"]
     - slides: ["fallback"]
-    - critic: ["fallback", "fallback_extra"]
-    # Planner: glm-5.1 -> qwen 3.5 -> nemotron 3 -> gemini 3.1 flash lite preview. No hop into ``fallback``.
-    - planner: ["planner_2"]
-    - planner_2: ["planner_3"]
-    - planner_3: ["planner_4"]
+    - critic: ["fallback", "app"]
     # - writer: ["fallback"]
     # - fast: ["fallback"]
 
@@ -40,10 +37,9 @@ router:
         - model: "gemini/gemini-3.1-flash-lite-preview"
           model_name: "slides"
           rpm: 15
-        # Fourth planner tier (LiteLLM group ``planner_4``); not used by ``app`` / ``slides``.
         - model: "gemini/gemini-3.1-flash-lite-preview"
-          model_name: "planner_4"
           rpm: 15
+          model_name: "fallback"
 
   # Note: splitting fallback_providers into *_high and *_rest allows us to control the
   # exact model-level fallback order across different providers (e.g. OpenRouter -> Ollama -> OpenRouter)
@@ -53,49 +49,49 @@ router:
       api_key: "os.environ/OPENROUTER_API_KEY"
       api_base: "os.environ/OPENROUTER_BASE_URL"
       models:
-        # Third planner tier (``planner_3``) and critic: Nemotron 3 Super; extra rows = same pool order for ``fallback``.
-        # Nemotron 3 and elephant-alpha store used prompts and completions for their own use.
+        # Planner Tier 2: Nemotron 3 Super
         - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
-          model_name: "planner_3"
+          model_name: "planner"
+          order: 2
+        # Planner Tier 3: Elephant Alpha
+        - model: "openrouter/elephant-alpha"
+          model_name: "planner"
+          order: 3
+        # Critic first preference
         - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
           model_name: "critic"
+
         - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
         - model: "openrouter/elephant-alpha"
-        - model: "openrouter/z-ai/glm-4.5-air:free"
 
     ollama_high:
       api_key: "os.environ/OLLAMA_API_KEY"
       api_base: "os.environ/OLLAMA_BASE_URL"
       models:
-        # First planner tier (``planner``); duplicate row keeps ``fallback`` pool order/contents.
-        - model: "ollama/glm-5.1:cloud"
-          model_name: "planner"
-        - model: "ollama/glm-5.1:cloud"
-        # Second planner tier (``planner_2``): Qwen 3.5
+        # Planner Tier 1: Qwen 3.5
         - model: "ollama/qwen3.5:397b-cloud"
-          model_name: "planner_2"
+          model_name: "planner"
+          order: 1
           timeout: 180
+          #- model: "ollama/glm-5.1:cloud"  # Often unavailable (524 error)
 
-    gemini_rest:
+    gemini_basic:
       api_key: "os.environ/GEMINI_API_KEY"
       models:
-        - model: "gemini/gemini-3.1-flash-lite-preview"
-          model_name: "fallback_extra"
-          rpm: 15
         - model: "gemini/gemma-4-31b-it"
           rpm: 15
 
-    ollama_rest:
+    ollama_basic:
       api_key: "os.environ/OLLAMA_API_KEY"
       api_base: "os.environ/OLLAMA_BASE_URL"
       models:
         - model: "ollama/gemma4:31b-cloud"
 
-    openrouter_rest:
-      api_key: "os.environ/OPENROUTER_API_KEY"
-      api_base: "os.environ/OPENROUTER_BASE_URL"
-      models:
-        - model: "openrouter/openai/gpt-oss-120b:free"  # Does not support structured output
+#    openrouter_basic:
+#      api_key: "os.environ/OPENROUTER_API_KEY"
+#      api_base: "os.environ/OPENROUTER_BASE_URL"
+#      models:
+#        - model: "openrouter/openai/gpt-oss-120b:free"  # Does not support structured output
 
   settings:
     num_retries: 2
@@ -103,3 +99,4 @@ router:
     cooldown_time: 30
     enable_pre_call_checks: true
     timeout: 120
+    routing_strategy: "usage-based-routing"

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -135,7 +135,7 @@ def build_litellm_model_list(
                 effective_alias = default_alias
             
             out_row = {"model_name": effective_alias, "litellm_params": merged}
-            for key in ["rpm", "tpm"]:
+            for key in ["rpm", "tpm", "tps", "weight", "order"]:
                 if key in merged:
                     out_row[key] = merged.pop(key)
             out.append(out_row)

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -122,6 +122,17 @@ class ResearchDatabase(DatabaseProvider):
                     if "paper_metadata" not in doc_columns:
                         self._conn.execute("ALTER TABLE documents ADD COLUMN paper_metadata TEXT;")
 
+                image_columns = [info["name"] for info in self._conn.execute("PRAGMA table_info(images)").fetchall()]
+                if image_columns:
+                    if "bbox" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN bbox TEXT;")
+                    if "source_filename" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN source_filename TEXT;")
+                    if "confidence" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN confidence REAL;")
+                    if "category" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN category TEXT;")
+
                 slide_columns = [
                     info["name"] for info in self._conn.execute("PRAGMA table_info(proto_slides)").fetchall()
                 ]

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -132,6 +132,22 @@ class ResearchDatabase(DatabaseProvider):
                         self._conn.execute("ALTER TABLE images ADD COLUMN confidence REAL;")
                     if "category" not in image_columns:
                         self._conn.execute("ALTER TABLE images ADD COLUMN category TEXT;")
+                    if "vlm_caption" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN vlm_caption TEXT;")
+                    if "mermaid" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN mermaid TEXT;")
+                    if "figure_group_id" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN figure_group_id TEXT;")
+                    if "figure_label" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN figure_label TEXT;")
+                    if "figure_number" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN figure_number INTEGER;")
+                    if "panel_index" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN panel_index INTEGER;")
+                    if "panel_role" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN panel_role TEXT;")
+                    if "identity_signal" not in image_columns:
+                        self._conn.execute("ALTER TABLE images ADD COLUMN identity_signal TEXT;")
 
                 slide_columns = [
                     info["name"] for info in self._conn.execute("PRAGMA table_info(proto_slides)").fetchall()

--- a/src/memory/research/document.py
+++ b/src/memory/research/document.py
@@ -15,6 +15,36 @@ from src.processing.document.schema import (
 )
 
 
+def _extracted_image_from_row(row) -> ExtractedImage:
+    """Build ExtractedImage from sqlite Row; tolerate older DB rows missing new columns."""
+    keys = row.keys()
+
+    def _col(name: str, default):
+        return row[name] if name in keys else default
+
+    return ExtractedImage(
+        id=row["id"],
+        mime_type=row["mime_type"],
+        base64_data=row["base64_data"] or "",
+        page=row["page_number"],
+        caption=row["caption"] or "",
+        storage_path=row["storage_path"],
+        contextualized_text=row["contextualized_text"],
+        bbox=json.loads(row["bbox"]) if row["bbox"] else None,
+        source_filename=row["source_filename"],
+        confidence=row["confidence"],
+        category=row["category"],
+        vlm_caption=_col("vlm_caption", "") or "",
+        mermaid=_col("mermaid", None),
+        figure_group_id=_col("figure_group_id", None),
+        figure_label=_col("figure_label", None),
+        figure_number=_col("figure_number", None),
+        panel_index=_col("panel_index", None),
+        panel_role=_col("panel_role", None),
+        identity_signal=_col("identity_signal", None),
+    )
+
+
 def _load_ordered_chunk_rows(db, doc_id):
     """Return chunk rows in document order, falling back to insertion order."""
     return db.connection.execute(
@@ -82,8 +112,9 @@ def save_document(db, result: ExtractionResult) -> None:
             db._conn.execute(
                 """
                 INSERT OR REPLACE INTO images
-                (id, document_id, mime_type, base64_data, storage_path, page_number, caption, contextualized_text, bbox, source_filename, confidence, category)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (id, document_id, mime_type, base64_data, storage_path, page_number, caption, contextualized_text, bbox, source_filename, confidence, category,
+                 vlm_caption, mermaid, figure_group_id, figure_label, figure_number, panel_index, panel_role, identity_signal)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     img.id,
@@ -98,6 +129,14 @@ def save_document(db, result: ExtractionResult) -> None:
                     img.source_filename,
                     img.confidence,
                     img.category,
+                    img.vlm_caption or "",
+                    img.mermaid,
+                    img.figure_group_id,
+                    img.figure_label,
+                    img.figure_number,
+                    img.panel_index,
+                    img.panel_role,
+                    img.identity_signal,
                 )
             )
 
@@ -187,21 +226,7 @@ def load_document(db, doc_id: str) -> ExtractionResult | None:
         return None
 
     img_rows = db._conn.execute("SELECT * FROM images WHERE document_id = ?", (doc_id,)).fetchall()
-    images = [
-        ExtractedImage(
-            id=row["id"],
-            mime_type=row["mime_type"],
-            base64_data=row["base64_data"] or "",
-            page=row["page_number"],
-            caption=row["caption"] or "",
-            storage_path=row["storage_path"],
-            contextualized_text=row["contextualized_text"],
-            bbox=json.loads(row["bbox"]) if row["bbox"] else None,
-            source_filename=row["source_filename"],
-            confidence=row["confidence"],
-            category=row["category"],
-        ) for row in img_rows
-    ]
+    images = [_extracted_image_from_row(row) for row in img_rows]
 
     tbl_rows = db._conn.execute("SELECT * FROM tables WHERE document_id = ?", (doc_id,)).fetchall()
     tables = [
@@ -262,19 +287,7 @@ def get_image(db, image_id: str) -> ExtractedImage | None:
     row = db._conn.execute("SELECT * FROM images WHERE id = ?", (image_id,)).fetchone()
     if not row:
         return None
-    return ExtractedImage(
-        id=row["id"],
-        mime_type=row["mime_type"],
-        base64_data=row["base64_data"] or "",
-        page=row["page_number"],
-        caption=row["caption"] or "",
-        storage_path=row["storage_path"],
-        contextualized_text=row["contextualized_text"],
-        bbox=json.loads(row["bbox"]) if row["bbox"] else None,
-        source_filename=row["source_filename"],
-        confidence=row["confidence"],
-        category=row["category"],
-    )
+    return _extracted_image_from_row(row)
 
 
 def get_table(db, table_id: str) -> ExtractedTable | None:

--- a/src/memory/research/document.py
+++ b/src/memory/research/document.py
@@ -82,8 +82,8 @@ def save_document(db, result: ExtractionResult) -> None:
             db._conn.execute(
                 """
                 INSERT OR REPLACE INTO images
-                (id, document_id, mime_type, base64_data, storage_path, page_number, caption, contextualized_text)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (id, document_id, mime_type, base64_data, storage_path, page_number, caption, contextualized_text, bbox, source_filename, confidence, category)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     img.id,
@@ -94,6 +94,10 @@ def save_document(db, result: ExtractionResult) -> None:
                     img.page,
                     img.caption,
                     img.contextualized_text,
+                    json.dumps(img.bbox) if img.bbox else None,
+                    img.source_filename,
+                    img.confidence,
+                    img.category,
                 )
             )
 
@@ -192,6 +196,10 @@ def load_document(db, doc_id: str) -> ExtractionResult | None:
             caption=row["caption"] or "",
             storage_path=row["storage_path"],
             contextualized_text=row["contextualized_text"],
+            bbox=json.loads(row["bbox"]) if row["bbox"] else None,
+            source_filename=row["source_filename"],
+            confidence=row["confidence"],
+            category=row["category"],
         ) for row in img_rows
     ]
 
@@ -262,6 +270,10 @@ def get_image(db, image_id: str) -> ExtractedImage | None:
         caption=row["caption"] or "",
         storage_path=row["storage_path"],
         contextualized_text=row["contextualized_text"],
+        bbox=json.loads(row["bbox"]) if row["bbox"] else None,
+        source_filename=row["source_filename"],
+        confidence=row["confidence"],
+        category=row["category"],
     )
 
 

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -134,6 +134,14 @@ CREATE TABLE IF NOT EXISTS images (
     source_filename TEXT,
     confidence REAL,
     category TEXT,
+    vlm_caption TEXT,
+    mermaid TEXT,
+    figure_group_id TEXT,
+    figure_label TEXT,
+    figure_number INTEGER,
+    panel_index INTEGER,
+    panel_role TEXT,
+    identity_signal TEXT,
     FOREIGN KEY (document_id) REFERENCES documents(id)
 );
 """

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -130,6 +130,10 @@ CREATE TABLE IF NOT EXISTS images (
     page_number INTEGER,
     caption TEXT,
     contextualized_text TEXT,
+    bbox TEXT,
+    source_filename TEXT,
+    confidence REAL,
+    category TEXT,
     FOREIGN KEY (document_id) REFERENCES documents(id)
 );
 """

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -63,6 +63,7 @@ _PARSE_KWARGS: dict[str, Any] = {
                 "output_tables_as_markdown": False,
                 "merge_continued_tables": True,
             },
+            "inline_images": True,
             "annotate_links": True,
         },
         "extract_printed_page_number": True,

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -18,10 +18,16 @@ from ..backend_base import OCRBackend
 from ..schema import (
     ExtractedChunk,
     ExtractedEquation,
-    ExtractedImage,
     ExtractedTable,
     ExtractionResult,
     PaperMetadata,
+)
+from .llama_parse_figures import (
+    assign_entries_to_anchors,
+    build_extracted_images,
+    collect_figure_anchors,
+    iter_layout_entries,
+    rewrite_markdown_images_and_tables,
 )
 
 _TIER = "agentic"
@@ -48,7 +54,6 @@ _PARSE_KWARGS: dict[str, Any] = {
             "CRITICAL: For every figure or diagram, you MUST include the original "
             "Markdown image reference tag (e.g., ![caption](image)) immediately "
             "before any Mermaid or HTML transcription you provide. Never omit the image tag."
-            "For every table, include its full caption or title above the table. "
             "Preserve section headings exactly as they appear."
         ),
     },
@@ -128,10 +133,6 @@ _RE_DOI = re.compile(r"\bdoi[:\s]+([^\s,;\)]+)", re.IGNORECASE)
 _RE_YEAR = re.compile(r"\b(19|20)\d{2}\b")
 _RE_BLOCK_EQ = re.compile(r"\$\$(.+?)\$\$", re.DOTALL)
 
-# Matches Markdown image syntax used by LlamaParse: ![alt](url-or-filename)
-_IMAGE_REF_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
-# Matches inline HTML tables emitted by LlamaParse (output_tables_as_markdown=False)
-_HTML_TABLE_PATTERN = re.compile(r"(<table[\s\S]*?</table>)", re.IGNORECASE | re.DOTALL)
 # Extracts the page number from a LlamaParse layout filename, e.g. 'page_4_chart_1_v2.jpg' → 4
 _PAGE_IN_FILENAME_RE = re.compile(r"\bpage_(\d+)_")
 
@@ -243,76 +244,6 @@ def _extract_equations_from_markdown(doc_id: str, markdown: str) -> list[Extract
         counter += 1
 
     return equations
-def _rewrite_markdown_refs(
-    markdown: str,
-    image_url_to_id: dict[str, str],
-    image_caption_to_id: dict[str, str],
-    table_ids: list[str],
-    page_to_img_ids: dict[int, list[str]] | None = None,
-    img_id_to_page: dict[str, int] | None = None,
-) -> str:
-    """
-    Replace LlamaParse's temporary presigned image URLs and inline HTML tables
-    with stable cross-reference tokens so chunks stay linked to DB records.
-
-    Image refs:  ``![caption](https://presigned-url...)``  →  ``[[img:{id}]]``
-    Image refs:  ``![caption](image)``  (LLM placeholder) →  ``[[img:{id}]]``  (matched by caption)
-    Table refs:  ``<table>...</table>``                    →  ``[[tbl:{id}]]``
-
-    Multi-panel figures: when a primary image is placed its same-page siblings
-    are emitted as additional tokens immediately adjacent, preventing them from
-    being stolen by the next caption match further in the document.
-    """
-    _page_to_imgs = page_to_img_ids or {}
-    _img_to_page = img_id_to_page or {}
-    used_ids: set[str] = set()
-
-    def _image_repl(match: re.Match) -> str:
-        alt = match.group(1).strip()
-        url = match.group(2).strip()
-
-        # Primary: match on URL, basename, or filename
-        img_id = (
-            image_url_to_id.get(url)
-            or image_url_to_id.get(Path(url).name)
-        )
-
-        # Fallback: LlamaParse agentic tier uses url='image' as a placeholder;
-        # in that case match on the alt text, which equals the figure caption.
-        if not img_id and url == "image" and alt:
-            img_id = image_caption_to_id.get(alt)
-
-        if not img_id or img_id in used_ids:
-            return match.group(0)  # leave unrecognised or already-placed refs intact
-
-        tokens: list[str] = [f"[[img:{img_id}]]"]
-        used_ids.add(img_id)
-
-        # Sibling tokens: other layout images sharing the same page that haven't
-        # been placed yet. These are sub-panels of the same multi-part figure.
-        page = _img_to_page.get(img_id)
-        if page is not None:
-            for sibling_id in _page_to_imgs.get(page, []):
-                if sibling_id != img_id and sibling_id not in used_ids:
-                    tokens.append(f"[[img:{sibling_id}]]")
-                    used_ids.add(sibling_id)
-
-        return " ".join(tokens)
-
-    markdown = _IMAGE_REF_PATTERN.sub(_image_repl, markdown)
-
-    # Replace the N-th <table>…</table> block with the N-th table token.
-    tbl_index = [0]  # mutable cell for closure
-
-    def _table_repl(match: re.Match) -> str:
-        i = tbl_index[0]
-        tbl_index[0] += 1
-        if i < len(table_ids):
-            return f"[[tbl:{table_ids[i]}]]"
-        return match.group(0)  # more HTML tables than extracted → leave as-is
-
-    markdown = _HTML_TABLE_PATTERN.sub(_table_repl, markdown)
-    return markdown
 
 
 def _is_garbage_table(html: str, rows: list) -> bool:
@@ -374,31 +305,49 @@ class LlamaParseBackend(OCRBackend):
         pages = _attr(metadata_block, "pages") or []
         page_count = len(pages)
 
-        # ── Extract tables & images first so we can build reference maps ──────
+        # ── Extract tables & figure-anchored images (geometry + captions) ────
         tables = self._extract_tables(doc_id, parse_result)
-        images = self._extract_images(doc_id, parse_result)
         equations = _extract_equations_from_markdown(doc_id, markdown_full)
         paper_metadata = _parse_paper_metadata(markdown_full) if markdown_full else None
 
-        # ── Rewrite markdown: replace presigned URLs / HTML tables with tokens ─
-        image_url_to_id, image_caption_to_id, page_to_img_ids, img_id_to_page = \
-            self._build_image_url_map(doc_id, parse_result)
-        table_ids = [tbl.id for tbl in tables]
-        rewritten_markdown = _rewrite_markdown_refs(
-            markdown_full,
-            image_url_to_id,
-            image_caption_to_id,
-            table_ids,
-            page_to_img_ids=page_to_img_ids,
-            img_id_to_page=img_id_to_page,
+        anchors = collect_figure_anchors(parse_result)
+        layout_entries = iter_layout_entries(parse_result)
+        assignments = assign_entries_to_anchors(anchors, layout_entries)
+
+        def _dl(url: str) -> bytes:
+            return _download_bytes_with_retry(
+                url,
+                attempts=_IMAGE_DOWNLOAD_MAX_ATTEMPTS,
+                backoff_seconds=_IMAGE_DOWNLOAD_BACKOFF_SECONDS,
+            )
+
+        def _store(key: str, data: bytes) -> str:
+            return self._object_store.write(key, data)
+
+        images, image_repl_map, loose_url_map, mermaid_fences = build_extracted_images(
+            doc_id,
+            anchors,
+            assignments,
+            layout_entries,
+            download_bytes=_dl,
+            write_to_store=_store,
+            id_prefix=_LP_ID_PREFIX,
         )
 
-        if image_url_to_id or image_caption_to_id or table_ids:
-            self._logger.log(
-                f"[LlamaParseBackend] Rewrote markdown refs: "
-                f"url_mapped={len(image_url_to_id)} caption_mapped={len(image_caption_to_id)} "
-                f"pages_with_images={len(page_to_img_ids)} table_tokens={len(table_ids)}"
-            )
+        table_ids = [tbl.id for tbl in tables]
+        rewritten_markdown = rewrite_markdown_images_and_tables(
+            markdown_full,
+            image_repl_map,
+            loose_url_map,
+            mermaid_fences,
+            table_ids,
+        )
+
+        self._logger.log(
+            f"[LlamaParseBackend] Figure anchors={len(anchors)} layout_entries={len(layout_entries)} "
+            f"images_extracted={len(images)} image_replacements={len(image_repl_map)} "
+            f"mermaid_strips={len(mermaid_fences)} table_tokens={len(table_ids)}"
+        )
 
         # ── Chunk the rewritten markdown ───────────────────────────────────────
         chunks = self._extract_chunks(doc_id, rewritten_markdown)
@@ -460,82 +409,6 @@ class LlamaParseBackend(OCRBackend):
                 )
                 time.sleep(sleep_s)
         raise RuntimeError(f"LlamaParse parse failed after retries: {last_exc}") from last_exc
-
-    def _build_image_url_map(
-        self, doc_id: str, parse_result: Any
-    ) -> tuple[dict[str, str], dict[str, str], dict[int, list[str]], dict[str, int]]:
-        """
-        Build lookup dicts for rewriting image refs in markdown_full.
-
-        Returns:
-            url_to_id:       presigned URL / filename / basename → img_id
-            caption_to_id:   figure caption text → img_id
-                             (only the FIRST layout image per page is caption-eligible;
-                             subsequent images on the same page are sub-panels that get
-                             emitted as siblings rather than matched by caption)
-            page_to_img_ids: page number → ordered list of img_ids on that page
-            img_id_to_page:  img_id → page number (reverse of page_to_img_ids)
-        """
-        url_to_id: dict[str, str] = {}
-        caption_to_id: dict[str, str] = {}
-        page_to_img_ids: dict[int, list[str]] = {}
-        img_id_to_page: dict[str, int] = {}
-
-        # ─ Step 1: caption → ordinal position, using the items walk ──────────────
-        items_block = _attr(parse_result, "items")
-        item_pages = _attr(items_block, "pages") or []
-        img_item_counter = 0
-        meta_index_to_caption: dict[int, str] = {}
-        for page in item_pages:
-            for item in (_attr(page, "items") or []):
-                if str(_attr(item, "type", "")).lower() == "image":
-                    caption = str(_attr(item, "caption") or "").strip()
-                    if caption:
-                        meta_index_to_caption[img_item_counter] = caption
-                    img_item_counter += 1
-
-        # ─ Step 2: walk images_content_metadata ──────────────────────────
-        images_meta = _attr(parse_result, "images_content_metadata")
-        image_entries = _attr(images_meta, "images") or []
-
-        caption_counter = 0            # only advances for the first image on each new page
-        last_caption_page: int | None = None
-
-        for entry in image_entries:
-            category = str(_attr(entry, "category") or "").lower()
-            if category in ("screenshot", "embedded"):
-                continue  # mirrors the filter in _extract_images
-
-            presigned_url: str | None = _attr(entry, "presigned_url")
-            if not presigned_url:
-                continue
-
-            index: int = _attr(entry, "index", 0)
-            filename: str = str(_attr(entry, "filename") or f"img_{index}.bin")
-            img_id = f"{doc_id}_{_LP_ID_PREFIX}_img_{index + 1:03d}"
-
-            # URL/filename map
-            url_to_id[presigned_url] = img_id
-            url_to_id[filename] = img_id
-            url_to_id[Path(filename).name] = img_id
-
-            # Page grouping
-            page_num = _page_from_filename(filename)
-            if page_num is not None:
-                page_to_img_ids.setdefault(page_num, []).append(img_id)
-                img_id_to_page[img_id] = page_num
-
-            # Caption map: only the FIRST layout image on each page gets a caption.
-            # Subsequent images on the same page are sub-panels; they are emitted
-            # as siblings of the primary token rather than having their own entry.
-            if page_num != last_caption_page:
-                caption = meta_index_to_caption.get(caption_counter)
-                if caption:
-                    caption_to_id[caption] = img_id
-                caption_counter += 1
-                last_caption_page = page_num
-
-        return url_to_id, caption_to_id, page_to_img_ids, img_id_to_page
 
     def _extract_chunks(self, doc_id: str, markdown_full: str) -> list[ExtractedChunk]:
         text = markdown_full.strip()
@@ -636,120 +509,6 @@ class LlamaParseBackend(OCRBackend):
                 counter += 1
 
         return tables
-
-    def _extract_images(self, doc_id: str, parse_result: Any) -> list[ExtractedImage]:
-        """
-        Download embedded figures from presigned URLs in images_content_metadata.
-
-        ImagesContentMetadataImage fields:
-            filename      str            ← for extension detection
-            index         int            ← 0-based order
-            presigned_url str | None     ← download URL (expires ~15 min)
-            content_type  str | None     ← MIME type e.g. "image/png"
-            category      str | None     ← "embedded" | "screenshot" | "layout"
-            bbox          BBox | None    ← position on page
-            size_bytes    int | None
-
-        Caption and Confidence are NOT on ImagesContentMetadataImage — they live on the
-        corresponding ImageItem in items.pages[*].items. We build a lookup
-        map from index → (caption, confidence) using the items tree first.
-        """
-        
-        meta_by_index: dict[int, dict[str, Any]] = {}
-        items_block = _attr(parse_result, "items")
-        item_pages = _attr(items_block, "pages") or []
-        img_item_counter = 0  # items are 0-indexed globally in order
-        for page in item_pages:
-            for item in (_attr(page, "items") or []):
-                if str(_attr(item, "type", "")).lower() == "image":
-                    caption = str(_attr(item, "caption") or "").strip()
-                    # Item bbox is a list of dicts with confidence
-                    item_bboxes = _attr(item, "bbox") or []
-                    confidence = _attr(item_bboxes[0], "confidence") if item_bboxes else None
-                    
-                    meta_by_index[img_item_counter] = {
-                        "caption": caption,
-                        "confidence": confidence
-                    }
-                    img_item_counter += 1
-
-        images_meta = _attr(parse_result, "images_content_metadata")
-        image_entries = _attr(images_meta, "images") or []
-
-        # Caption assignment: only the FIRST layout image on each page gets a
-        # caption from the items tree.  Additional images on the same page are
-        # sub-panels of the same figure; they are stored without a caption and
-        # referenced via the sibling-injection mechanism in _rewrite_markdown_refs.
-        caption_counter: int = 0
-        last_caption_page: int | None = None
-
-        extracted: list[ExtractedImage] = []
-        for entry in image_entries:
-            category = str(_attr(entry, "category") or "").lower()
-            # Only keep layout detections — these cover every page, including
-            # pages where figures are not embedded PDF objects.
-            # Skip screenshots and embedded objects.
-            if category in ("screenshot", "embedded"):
-                continue
-
-            presigned_url: str | None = _attr(entry, "presigned_url")
-            if not presigned_url:
-                continue
-
-            index: int = _attr(entry, "index", 0)
-            filename: str = str(_attr(entry, "filename") or f"img_{index}.bin")
-            mime_type: str = str(_attr(entry, "content_type") or "application/octet-stream")
-            raw_bbox = _attr(entry, "bbox")
-            bbox = _serialize_parse_payload(raw_bbox) if raw_bbox else None
-
-            # Advance caption only when we move to a new page.
-            page_num = _page_from_filename(filename)
-            confidence = None
-            if page_num != last_caption_page:
-                item_meta = meta_by_index.get(caption_counter, {})
-                caption = item_meta.get("caption", "")
-                confidence = item_meta.get("confidence")
-                caption_counter += 1
-                last_caption_page = page_num
-            else:
-                caption = ""  # sub-panel, no separate caption
-
-            try:
-                image_bytes = _download_bytes_with_retry(
-                    presigned_url,
-                    attempts=_IMAGE_DOWNLOAD_MAX_ATTEMPTS,
-                    backoff_seconds=_IMAGE_DOWNLOAD_BACKOFF_SECONDS,
-                )
-            except Exception as exc:
-                print(f"[LlamaParseBackend] Failed to download image {filename}: {exc}")
-                continue
-
-            img_id = f"{doc_id}_{_LP_ID_PREFIX}_img_{index + 1:03d}"
-            ext = _extension(filename, mime_type)
-            storage_key = f"{doc_id}/images/{img_id}.{ext}"
-            storage_path: str | None = None
-            base64_data = ""
-            try:
-                storage_path = self._object_store.write(storage_key, image_bytes)
-            except Exception as exc:
-                print(f"[LlamaParseBackend] Failed to store image {filename} in object store: {exc}")
-                # Fallback to storing as base64 data
-                base64_data = base64.b64encode(image_bytes).decode("utf-8")
-
-            extracted.append(ExtractedImage(
-                id=img_id,
-                mime_type=mime_type,
-                base64_data=base64_data,
-                page=page_num,
-                caption=caption,
-                storage_path=storage_path,
-                bbox=bbox,
-                source_filename=filename,
-                confidence=confidence,
-                category=category,
-            ))
-
-        return extracted
 
 
 def _download_bytes(url: str, timeout: int = 30) -> bytes:

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -31,7 +31,7 @@ from .llama_parse_figures import (
     rewrite_markdown_images_and_tables,
 )
 
-_TIER = "agentic"
+_TIER = "agentic"  # agentic_plus is the highest tier of LlamaParse, agentic is 4x cheaper (and roughly 4-6x faster)
 # Prefix embedded in every artifact ID produced by this backend.
 # Other backends should define their own prefix (e.g. "dl" for Docling)
 # so IDs remain self-describing and collision-free across providers.

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -27,6 +27,7 @@ from .llama_parse_figures import (
     build_extracted_images,
     collect_figure_anchors,
     iter_layout_entries,
+    rescue_orphan_figure_entries,
     rewrite_markdown_images_and_tables,
 )
 
@@ -313,6 +314,9 @@ class LlamaParseBackend(OCRBackend):
         anchors = collect_figure_anchors(parse_result)
         layout_entries = iter_layout_entries(parse_result)
         assignments = assign_entries_to_anchors(anchors, layout_entries)
+        anchors, assignments = rescue_orphan_figure_entries(
+            parse_result, anchors, assignments, layout_entries
+        )
 
         def _dl(url: str) -> bytes:
             return _download_bytes_with_retry(

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -45,6 +45,9 @@ _PARSE_KWARGS: dict[str, Any] = {
             "Render all mathematical equations in LaTeX notation. "
             "Inline equations: $equation$. Block/display equations: $$equation$$. "
             "For every figure or image, include its full caption verbatim. "
+            "CRITICAL: For every figure or diagram, you MUST include the original "
+            "Markdown image reference tag (e.g., ![caption](image)) immediately "
+            "before any Mermaid or HTML transcription you provide. Never omit the image tag."
             "For every table, include its full caption or title above the table. "
             "Preserve section headings exactly as they appear."
         ),
@@ -63,7 +66,7 @@ _PARSE_KWARGS: dict[str, Any] = {
                 "output_tables_as_markdown": False,
                 "merge_continued_tables": True,
             },
-            "inline_images": True,
+            #"inline_images": True,
             "annotate_links": True,
         },
         "extract_printed_page_number": True,
@@ -647,12 +650,12 @@ class LlamaParseBackend(OCRBackend):
             bbox          BBox | None    ← position on page
             size_bytes    int | None
 
-        Caption is NOT on ImagesContentMetadataImage — it lives on the
+        Caption and Confidence are NOT on ImagesContentMetadataImage — they live on the
         corresponding ImageItem in items.pages[*].items. We build a lookup
-        map from index → caption using the items tree first.
+        map from index → (caption, confidence) using the items tree first.
         """
         
-        caption_by_index: dict[int, str] = {}
+        meta_by_index: dict[int, dict[str, Any]] = {}
         items_block = _attr(parse_result, "items")
         item_pages = _attr(items_block, "pages") or []
         img_item_counter = 0  # items are 0-indexed globally in order
@@ -660,8 +663,14 @@ class LlamaParseBackend(OCRBackend):
             for item in (_attr(page, "items") or []):
                 if str(_attr(item, "type", "")).lower() == "image":
                     caption = str(_attr(item, "caption") or "").strip()
-                    if caption:
-                        caption_by_index[img_item_counter] = caption
+                    # Item bbox is a list of dicts with confidence
+                    item_bboxes = _attr(item, "bbox") or []
+                    confidence = _attr(item_bboxes[0], "confidence") if item_bboxes else None
+                    
+                    meta_by_index[img_item_counter] = {
+                        "caption": caption,
+                        "confidence": confidence
+                    }
                     img_item_counter += 1
 
         images_meta = _attr(parse_result, "images_content_metadata")
@@ -690,11 +699,16 @@ class LlamaParseBackend(OCRBackend):
             index: int = _attr(entry, "index", 0)
             filename: str = str(_attr(entry, "filename") or f"img_{index}.bin")
             mime_type: str = str(_attr(entry, "content_type") or "application/octet-stream")
+            raw_bbox = _attr(entry, "bbox")
+            bbox = _serialize_parse_payload(raw_bbox) if raw_bbox else None
 
             # Advance caption only when we move to a new page.
             page_num = _page_from_filename(filename)
+            confidence = None
             if page_num != last_caption_page:
-                caption = caption_by_index.get(caption_counter, "")
+                item_meta = meta_by_index.get(caption_counter, {})
+                caption = item_meta.get("caption", "")
+                confidence = item_meta.get("confidence")
                 caption_counter += 1
                 last_caption_page = page_num
             else:
@@ -729,6 +743,10 @@ class LlamaParseBackend(OCRBackend):
                 page=page_num,
                 caption=caption,
                 storage_path=storage_path,
+                bbox=bbox,
+                source_filename=filename,
+                confidence=confidence,
+                category=category,
             ))
 
         return extracted

--- a/src/processing/document/backends/llama_parse_figures.py
+++ b/src/processing/document/backends/llama_parse_figures.py
@@ -114,9 +114,8 @@ def _coverage_of_entry_inside_anchor(
     ea = entry[2] * entry[3]
     return inter / ea if ea > 0 else 0.0
 
-
-_RE_FIGURE = re.compile(r"^(Figure\s*(\d+))\b", re.IGNORECASE)
-
+# "Figure 1", "FIGURE 2", "Fig. 3", "FIG. 4" (optional period after abbreviated Fig)
+_RE_FIGURE = re.compile(r"^((?:Figure|Fig\.?)\s*(\d+))\b", re.IGNORECASE)
 
 def _parse_figure_label(text: str) -> tuple[str | None, int | None]:
     if not text or not text.strip():

--- a/src/processing/document/backends/llama_parse_figures.py
+++ b/src/processing/document/backends/llama_parse_figures.py
@@ -1,0 +1,577 @@
+"""
+Figure-anchor normalization for LlamaParse: map markdown placeholders and geometry
+from images_content_metadata to ExtractedImage rows and [[img:id]] rewrite keys.
+"""
+from __future__ import annotations
+
+import base64
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from ..schema import ExtractedImage
+
+
+def _attr(obj: Any, key: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _serialize_bbox(raw: Any) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return {k: float(v) if isinstance(v, (int, float)) else v for k, v in raw.items()}
+    if hasattr(raw, "model_dump"):
+        d = raw.model_dump()
+        return _serialize_bbox(d) if isinstance(d, dict) else None
+    if hasattr(raw, "dict"):
+        d = raw.dict()
+        return _serialize_bbox(d) if isinstance(d, dict) else None
+    return None
+
+
+def _coerce_bbox_for_storage(raw: Any) -> dict[str, Any] | None:
+    """Normalize LlamaParse bbox objects to a JSON-serializable dict."""
+    d = _serialize_bbox(raw)
+    return d
+
+
+def _rect_from_bbox_dict(b: Any) -> tuple[float, float, float, float] | None:
+    if b is None:
+        return None
+    if not isinstance(b, dict):
+        return None
+    try:
+        x = float(b.get("x", 0))
+        y = float(b.get("y", 0))
+        w = float(b.get("w", 0))
+        h = float(b.get("h", 0))
+    except (TypeError, ValueError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return (x, y, w, h)
+
+
+def _union_bbox_segments(segments: list[Any]) -> tuple[float, float, float, float] | None:
+    rects: list[tuple[float, float, float, float]] = []
+    for seg in segments:
+        r = _rect_from_bbox_dict(seg if isinstance(seg, dict) else _serialize_bbox(seg))
+        if r:
+            rects.append(r)
+    if not rects:
+        return None
+    x0 = min(r[0] for r in rects)
+    y0 = min(r[1] for r in rects)
+    x1 = max(r[0] + r[2] for r in rects)
+    y1 = max(r[1] + r[3] for r in rects)
+    return (x0, y0, x1 - x0, y1 - y0)
+
+
+def _union_item_bbox(item: Any) -> tuple[float, float, float, float] | None:
+    segs = _attr(item, "bbox") or []
+    if not segs:
+        return None
+    return _union_bbox_segments(list(segs))
+
+
+def _intersection_area(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+    ax2, ay2 = a[0] + a[2], a[1] + a[3]
+    bx2, by2 = b[0] + b[2], b[1] + b[3]
+    ix0, iy0 = max(a[0], b[0]), max(a[1], b[1])
+    ix1, iy1 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0.0, ix1 - ix0), max(0.0, iy1 - iy0)
+    return iw * ih
+
+
+def _iou(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+    inter = _intersection_area(a, b)
+    if inter <= 0:
+        return 0.0
+    ua = a[2] * a[3] + b[2] * b[3] - inter
+    return inter / ua if ua > 0 else 0.0
+
+
+def _rect_center(r: tuple[float, float, float, float]) -> tuple[float, float]:
+    return (r[0] + r[2] / 2, r[1] + r[3] / 2)
+
+
+def _center_dist2(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+    ca, cb = _rect_center(a), _rect_center(b)
+    dx, dy = ca[0] - cb[0], ca[1] - cb[1]
+    return dx * dx + dy * dy
+
+
+def _coverage_of_entry_inside_anchor(
+    anchor: tuple[float, float, float, float], entry: tuple[float, float, float, float]
+) -> float:
+    inter = _intersection_area(anchor, entry)
+    ea = entry[2] * entry[3]
+    return inter / ea if ea > 0 else 0.0
+
+
+_RE_FIGURE = re.compile(r"^(Figure\s*(\d+))\b", re.IGNORECASE)
+
+
+def _parse_figure_label(text: str) -> tuple[str | None, int | None]:
+    if not text or not text.strip():
+        return None, None
+    m = _RE_FIGURE.search(text.strip())
+    if not m:
+        return None, None
+    label = m.group(1).strip()
+    try:
+        num = int(m.group(2))
+    except ValueError:
+        num = None
+    return label, num
+
+
+_IMAGE_REF_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+_HTML_TABLE_PATTERN = re.compile(r"(<table[\s\S]*?</table>)", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass
+class FigureAnchor:
+    page_number: int
+    alt: str
+    url: str
+    anchor_rect: tuple[float, float, float, float]
+    vlm_caption: str
+    mermaid_fence: str
+    source_caption: str
+    figure_label: str | None
+    figure_number: int | None
+    identity_signal: str
+    from_image_item: bool
+
+
+@dataclass
+class LayoutMetaEntry:
+    index: int
+    page: int
+    rect: tuple[float, float, float, float]
+    filename: str
+    presigned_url: str
+    mime_type: str
+    category: str
+    raw_bbox: Any = field(default=None)
+
+
+def collect_caption_labeled_items(page_items: list[Any]) -> list[tuple[str, tuple[float, float, float, float]]]:
+    """Text items with any bbox segment labeled 'caption'."""
+    out: list[tuple[str, tuple[float, float, float, float]]] = []
+    for it in page_items:
+        segs = _attr(it, "bbox") or []
+        cap_segs = [s for s in segs if str(_attr(s, "label", "")).lower() == "caption"]
+        if not cap_segs:
+            continue
+        r = _union_bbox_segments(cap_segs)
+        if not r:
+            continue
+        txt = str(_attr(it, "md") or _attr(it, "value") or "").strip()
+        if txt:
+            out.append((txt, r))
+    return out
+
+
+def _nearest_caption_text(
+    anchor_rect: tuple[float, float, float, float],
+    candidates: list[tuple[str, tuple[float, float, float, float]]],
+) -> tuple[str, tuple[float, float, float, float] | None] | None:
+    if not candidates:
+        return None
+    best: tuple[str, tuple[float, float, float, float]] | None = None
+    best_d = float("inf")
+    for txt, rect in candidates:
+        d = _center_dist2(anchor_rect, rect)
+        if d < best_d:
+            best_d = d
+            best = (txt, rect)
+    return best
+
+
+def _find_mermaid_fence(page_items: list[Any], anchor_rect: tuple[float, float, float, float]) -> str:
+    """Return full markdown fence (including ```) for co-occurring mermaid code block."""
+    for it in page_items:
+        if str(_attr(it, "type", "")).lower() != "code":
+            continue
+        lang = str(_attr(it, "language") or "").lower()
+        omd = str(_attr(it, "md") or "")
+        if lang != "mermaid" and not omd.lstrip().startswith("```mermaid"):
+            continue
+        orect = _union_item_bbox(it)
+        if not orect:
+            continue
+        if _iou(anchor_rect, orect) >= 0.25 or _coverage_of_entry_inside_anchor(anchor_rect, orect) >= 0.3:
+            return omd.strip()
+        if _coverage_of_entry_inside_anchor(orect, anchor_rect) >= 0.5:
+            return omd.strip()
+    return ""
+
+
+def collect_figure_anchors(parse_result: Any) -> list[FigureAnchor]:
+    items_block = _attr(parse_result, "items")
+    item_pages = _attr(items_block, "pages") or []
+    anchors: list[FigureAnchor] = []
+    for page in item_pages:
+        page_number = int(_attr(page, "page_number") or 0)
+        page_items = list(_attr(page, "items") or [])
+        cap_items = collect_caption_labeled_items(page_items)
+        for item in page_items:
+            val = str(_attr(item, "value") or "")
+            md = str(_attr(item, "md") or "")
+            # LlamaParse sometimes escapes brackets in md (!\\[) while value holds a valid ![alt](url).
+            scan = val if val and _IMAGE_REF_PATTERN.search(val) else md
+            if not scan:
+                continue
+            if not _IMAGE_REF_PATTERN.search(scan):
+                scan = scan.replace("!\\[", "![")
+            if "![" not in scan:
+                continue
+            itype = str(_attr(item, "type", "")).lower()
+            vlm = ""
+            if itype == "image":
+                vlm = str(_attr(item, "caption") or "").strip()
+            anchor_rect = _union_item_bbox(item)
+            if anchor_rect is None:
+                anchor_rect = (0.0, 0.0, 612.0, 792.0)
+            for m in _IMAGE_REF_PATTERN.finditer(scan):
+                alt = m.group(1).strip()
+                url = m.group(2).strip()
+                nearest = _nearest_caption_text(anchor_rect, cap_items)
+                source_caption = ""
+                figure_label: str | None = None
+                figure_number: int | None = None
+                identity_signal = "weak"
+                if nearest:
+                    source_caption, _crect = nearest[0], nearest[1]
+                    fl, fn = _parse_figure_label(source_caption)
+                    figure_label, figure_number = fl, fn
+                    identity_signal = "caption_item"
+                fl_alt, fn_alt = _parse_figure_label(alt)
+                if figure_number is None and fn_alt is not None:
+                    figure_label, figure_number = fl_alt, fn_alt
+                    identity_signal = "markdown_alt"
+                    if not source_caption:
+                        source_caption = alt
+                if not source_caption:
+                    source_caption = alt
+                vlm_eff = vlm
+                if vlm_eff and source_caption and vlm_eff.strip() == source_caption.strip():
+                    vlm_eff = ""
+                m_fence = _find_mermaid_fence(page_items, anchor_rect)
+                anchors.append(
+                    FigureAnchor(
+                        page_number=page_number,
+                        alt=alt,
+                        url=url,
+                        anchor_rect=anchor_rect,
+                        vlm_caption=vlm_eff,
+                        mermaid_fence=m_fence,
+                        source_caption=source_caption,
+                        figure_label=figure_label,
+                        figure_number=figure_number,
+                        identity_signal=identity_signal,
+                        from_image_item=(itype == "image"),
+                    )
+                )
+    return anchors
+
+
+def _page_num_from_filename(filename: str) -> int | None:
+    m = re.search(r"\bpage_(\d+)_", filename)
+    return int(m.group(1)) if m else None
+
+
+def iter_layout_entries(parse_result: Any) -> list[LayoutMetaEntry]:
+    images_meta = _attr(parse_result, "images_content_metadata")
+    image_entries = _attr(images_meta, "images") or []
+    out: list[LayoutMetaEntry] = []
+    for entry in image_entries:
+        category = str(_attr(entry, "category") or "").lower()
+        if category in ("screenshot", "embedded"):
+            continue
+        presigned_url: str | None = _attr(entry, "presigned_url")
+        if not presigned_url:
+            continue
+        index: int = int(_attr(entry, "index", 0))
+        filename = str(_attr(entry, "filename") or f"img_{index}.bin")
+        page = _page_num_from_filename(filename)
+        if page is None:
+            continue
+        raw_bbox = _attr(entry, "bbox")
+        bbox_dict = _coerce_bbox_for_storage(raw_bbox)
+        rect = _rect_from_bbox_dict(bbox_dict)
+        if not rect:
+            continue
+        mime_type = str(_attr(entry, "content_type") or "application/octet-stream")
+        out.append(
+            LayoutMetaEntry(
+                index=index,
+                page=page,
+                rect=rect,
+                filename=filename,
+                presigned_url=presigned_url,
+                mime_type=mime_type,
+                category=category,
+                raw_bbox=bbox_dict,
+            )
+        )
+    return out
+
+
+def assign_entries_to_anchors(
+    anchors: list[FigureAnchor], entries: list[LayoutMetaEntry]
+) -> list[list[LayoutMetaEntry]]:
+    """Assign each layout entry to the best-matching figure anchor on the same page."""
+    if not anchors:
+        return []
+    assignments: list[list[LayoutMetaEntry]] = [[] for _ in anchors]
+    used: set[int] = set()
+
+    def score(an: FigureAnchor, ent: LayoutMetaEntry) -> float:
+        if an.page_number != ent.page:
+            return -1.0
+        iou = _iou(an.anchor_rect, ent.rect)
+        cov = _coverage_of_entry_inside_anchor(an.anchor_rect, ent.rect)
+        if cov >= 0.45 or iou >= 0.08:
+            return max(iou, cov)
+        dist = _center_dist2(an.anchor_rect, ent.rect)
+        return 1.0 / (1.0 + dist / 50000.0)
+
+    for ent in sorted(entries, key=lambda e: e.index):
+        best_ai: int | None = None
+        best_sc = -1.0
+        for ai, an in enumerate(anchors):
+            s = score(an, ent)
+            if s > best_sc:
+                best_sc = s
+                best_ai = ai
+        if best_ai is not None and best_sc > 0.0001:
+            assignments[best_ai].append(ent)
+            used.add(ent.index)
+
+    for ent in entries:
+        if ent.index in used:
+            continue
+        best_ai = None
+        best_d = float("inf")
+        for ai, an in enumerate(anchors):
+            if an.page_number != ent.page:
+                continue
+            d = _center_dist2(an.anchor_rect, ent.rect)
+            if d < best_d:
+                best_d = d
+                best_ai = ai
+        if best_ai is not None:
+            assignments[best_ai].append(ent)
+            used.add(ent.index)
+
+    for lst in assignments:
+        lst.sort(key=lambda e: (e.rect[0], e.rect[1]))
+    return assignments
+
+
+def panel_role(n_panels: int, panel_index: int, rects: list[tuple[float, float, float, float]]) -> str | None:
+    if n_panels == 2:
+        return "left" if panel_index == 0 else "right"
+    return None
+
+
+def build_extracted_images(
+    doc_id: str,
+    anchors: list[FigureAnchor],
+    assignments: list[list[LayoutMetaEntry]],
+    layout_entries: list[LayoutMetaEntry],
+    download_bytes: Callable[[str], bytes],
+    write_to_store: Callable[[str, bytes], str],
+    id_prefix: str,
+) -> tuple[list[ExtractedImage], dict[tuple[str, str], str], dict[str, str], list[str]]:
+    """
+    Download layout images, populate ExtractedImage rows, build (alt,url)->token string map
+    plus loose URL maps so markdown_full (presigned S3 URLs) resolves to the same tokens.
+
+    Returns (images, alt_url_replacements, loose_url_replacements, mermaid_fences_to_strip).
+    """
+    images: list[ExtractedImage] = []
+    replacement_map: dict[tuple[str, str], str] = {}
+    loose_url_map: dict[str, str] = {}
+    mermaid_fences: list[str] = []
+
+    for ai, anch in enumerate(anchors):
+        group_id = f"{doc_id}_{id_prefix}_fig_{ai:03d}"
+        ents = assignments[ai] if ai < len(assignments) else []
+        tokens: list[str] = []
+        if not ents:
+            continue
+        n = len(ents)
+        rects = [e.rect for e in ents]
+        for pi, ent in enumerate(ents):
+            img_id = f"{doc_id}_{id_prefix}_img_{ent.index + 1:03d}"
+            tokens.append(f"[[img:{img_id}]]")
+            try:
+                image_bytes = download_bytes(ent.presigned_url)
+            except Exception:
+                image_bytes = b""
+
+            bbox_dict = _coerce_bbox_for_storage(ent.raw_bbox) if ent.raw_bbox is not None else None
+            ext = _guess_ext(ent.filename, ent.mime_type)
+            storage_key = f"{doc_id}/images/{img_id}.{ext}"
+            storage_path: str | None = None
+            base64_data = ""
+            try:
+                if image_bytes:
+                    storage_path = write_to_store(storage_key, image_bytes)
+            except Exception:
+                if image_bytes:
+                    base64_data = base64.b64encode(image_bytes).decode("utf-8")
+
+            pr = panel_role(n, pi, rects)
+            merm = anch.mermaid_fence if pi == 0 and anch.mermaid_fence else None
+            if merm and merm not in mermaid_fences:
+                mermaid_fences.append(merm)
+
+            images.append(
+                ExtractedImage(
+                    id=img_id,
+                    mime_type=ent.mime_type,
+                    base64_data=base64_data,
+                    page=ent.page,
+                    caption=anch.source_caption or "",
+                    storage_path=storage_path,
+                    bbox=bbox_dict,
+                    source_filename=ent.filename,
+                    confidence=None,
+                    category=ent.category,
+                    vlm_caption=anch.vlm_caption or "",
+                    mermaid=merm,
+                    figure_group_id=group_id,
+                    figure_label=anch.figure_label,
+                    figure_number=anch.figure_number,
+                    panel_index=pi,
+                    panel_role=pr,
+                    identity_signal=anch.identity_signal,
+                )
+            )
+
+        if tokens:
+            tok_str = " ".join(tokens)
+            replacement_map[(anch.alt, anch.url)] = tok_str
+            for ent in ents:
+                loose_url_map[ent.presigned_url] = tok_str
+                loose_url_map[ent.filename] = tok_str
+                loose_url_map[Path(ent.filename).name] = tok_str
+
+    assigned_idx: set[int] = set()
+    for lst in assignments:
+        for e in lst:
+            assigned_idx.add(e.index)
+
+    for ent in sorted(layout_entries, key=lambda e: e.index):
+        if ent.index in assigned_idx:
+            continue
+        img_id = f"{doc_id}_{id_prefix}_img_{ent.index + 1:03d}"
+        tok_str = f"[[img:{img_id}]]"
+        loose_url_map[ent.presigned_url] = tok_str
+        loose_url_map[ent.filename] = tok_str
+        loose_url_map[Path(ent.filename).name] = tok_str
+        try:
+            image_bytes = download_bytes(ent.presigned_url)
+        except Exception:
+            image_bytes = b""
+        bbox_dict = _coerce_bbox_for_storage(ent.raw_bbox) if ent.raw_bbox is not None else None
+        ext = _guess_ext(ent.filename, ent.mime_type)
+        storage_key = f"{doc_id}/images/{img_id}.{ext}"
+        storage_path: str | None = None
+        b64 = ""
+        try:
+            if image_bytes:
+                storage_path = write_to_store(storage_key, image_bytes)
+        except Exception:
+            if image_bytes:
+                b64 = base64.b64encode(image_bytes).decode("utf-8")
+        images.append(
+            ExtractedImage(
+                id=img_id,
+                mime_type=ent.mime_type,
+                base64_data=b64,
+                page=ent.page,
+                caption="",
+                storage_path=storage_path,
+                bbox=bbox_dict,
+                source_filename=ent.filename,
+                confidence=None,
+                category=ent.category,
+                vlm_caption="",
+                mermaid=None,
+                figure_group_id=f"{doc_id}_{id_prefix}_orphan_{ent.index:03d}",
+                figure_label=None,
+                figure_number=None,
+                panel_index=0,
+                panel_role=None,
+                identity_signal="layout_only",
+            )
+        )
+
+    return images, replacement_map, loose_url_map, mermaid_fences
+
+
+def _guess_ext(filename: str, mime_type: str) -> str:
+    if "." in filename:
+        ext = filename.rsplit(".", 1)[-1].strip().lower()
+        if ext and len(ext) <= 5:
+            return ext
+    return {
+        "image/png": "png",
+        "image/jpeg": "jpg",
+        "image/jpg": "jpg",
+        "image/webp": "webp",
+        "image/gif": "gif",
+        "image/tiff": "tiff",
+    }.get(mime_type, "bin")
+
+
+def rewrite_markdown_images_and_tables(
+    markdown: str,
+    image_key_to_tokens: dict[tuple[str, str], str],
+    loose_url_to_tokens: dict[str, str],
+    mermaid_fences_to_strip: list[str],
+    table_ids: list[str],
+) -> str:
+    """Replace ![alt](url) via exact (alt,url) map; strip mermaid blocks; then table tokens."""
+    md = markdown
+    for fence in mermaid_fences_to_strip:
+        if fence and fence in md:
+            md = md.replace(fence, "\n\n", 1)
+
+    def _img_repl(m: re.Match[str]) -> str:
+        alt = m.group(1).strip()
+        url = m.group(2).strip()
+        rep = image_key_to_tokens.get((alt, url))
+        if rep is None:
+            rep = loose_url_to_tokens.get(url)
+        if rep is None:
+            rep = loose_url_to_tokens.get(Path(url).name)
+        if rep is None:
+            return m.group(0)
+        return rep
+
+    md = _IMAGE_REF_PATTERN.sub(_img_repl, md)
+
+    tbl_index = [0]
+
+    def _table_repl(m: re.Match[str]) -> str:
+        i = tbl_index[0]
+        tbl_index[0] += 1
+        if i < len(table_ids):
+            return f"[[tbl:{table_ids[i]}]]"
+        return m.group(0)
+
+    md = _HTML_TABLE_PATTERN.sub(_table_repl, md)
+    return md

--- a/src/processing/document/backends/llama_parse_figures.py
+++ b/src/processing/document/backends/llama_parse_figures.py
@@ -135,6 +135,16 @@ def _parse_figure_label(text: str) -> tuple[str | None, int | None]:
 _IMAGE_REF_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 _HTML_TABLE_PATTERN = re.compile(r"(<table[\s\S]*?</table>)", re.IGNORECASE | re.DOTALL)
 
+# Geometry heuristics (PDF points, ~1pt ≈ 1/72 inch)
+_CAPTION_NEAREST_MAX_DIST_PX = 300.0
+"""Reject caption-labeled items whose center is farther than this from the anchor center."""
+
+_ASSIGN_REJECT_ABOVE_ANCHOR_GAP_PX = 100.0
+"""If a layout crop's bottom is this many px above the anchor top, skip distance-based match."""
+
+_RESCUE_CAPTION_MAX_GAP_PX = 200.0
+"""Max vertical gap (caption top minus entry bottom) for orphan layout rescue to a Figure N caption."""
+
 
 @dataclass
 class FigureAnchor:
@@ -183,6 +193,8 @@ def collect_caption_labeled_items(page_items: list[Any]) -> list[tuple[str, tupl
 def _nearest_caption_text(
     anchor_rect: tuple[float, float, float, float],
     candidates: list[tuple[str, tuple[float, float, float, float]]],
+    *,
+    max_dist: float | None = _CAPTION_NEAREST_MAX_DIST_PX,
 ) -> tuple[str, tuple[float, float, float, float] | None] | None:
     if not candidates:
         return None
@@ -193,7 +205,28 @@ def _nearest_caption_text(
         if d < best_d:
             best_d = d
             best = (txt, rect)
+    if best is None:
+        return None
+    if max_dist is not None and best_d > max_dist * max_dist:
+        return None
     return best
+
+
+def _horizontal_overlap_positive(
+    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+) -> bool:
+    ax1, bx1 = a[0] + a[2], b[0] + b[2]
+    return min(ax1, bx1) - max(a[0], b[0]) > 0.0
+
+
+def _entry_entirely_above_anchor_gap(
+    ent_rect: tuple[float, float, float, float],
+    anchor_rect: tuple[float, float, float, float],
+    gap_pt: float = _ASSIGN_REJECT_ABOVE_ANCHOR_GAP_PX,
+) -> bool:
+    entry_bottom = ent_rect[1] + ent_rect[3]
+    anchor_top = anchor_rect[1]
+    return entry_bottom < anchor_top - gap_pt
 
 
 def _find_mermaid_fence(page_items: list[Any], anchor_rect: tuple[float, float, float, float]) -> str:
@@ -342,6 +375,8 @@ def assign_entries_to_anchors(
         cov = _coverage_of_entry_inside_anchor(an.anchor_rect, ent.rect)
         if cov >= 0.45 or iou >= 0.08:
             return max(iou, cov)
+        if _entry_entirely_above_anchor_gap(ent.rect, an.anchor_rect):
+            return -1.0
         dist = _center_dist2(an.anchor_rect, ent.rect)
         return 1.0 / (1.0 + dist / 50000.0)
 
@@ -365,6 +400,8 @@ def assign_entries_to_anchors(
         for ai, an in enumerate(anchors):
             if an.page_number != ent.page:
                 continue
+            if _entry_entirely_above_anchor_gap(ent.rect, an.anchor_rect):
+                continue
             d = _center_dist2(an.anchor_rect, ent.rect)
             if d < best_d:
                 best_d = d
@@ -376,6 +413,78 @@ def assign_entries_to_anchors(
     for lst in assignments:
         lst.sort(key=lambda e: (e.rect[0], e.rect[1]))
     return assignments
+
+
+def rescue_orphan_figure_entries(
+    parse_result: Any,
+    anchors: list[FigureAnchor],
+    assignments: list[list[LayoutMetaEntry]],
+    layout_entries: list[LayoutMetaEntry],
+) -> tuple[list[FigureAnchor], list[list[LayoutMetaEntry]]]:
+    """
+    Attach unassigned layout crops to synthetic anchors when a Figure N caption sits
+    just below them (LlamaParse sometimes emits figure bodies as ``table`` items with
+    no ``![alt](url)``, so ``collect_figure_anchors`` never created an anchor).
+    """
+    assigned_idx: set[int] = set()
+    for lst in assignments:
+        for e in lst:
+            assigned_idx.add(e.index)
+
+    items_block = _attr(parse_result, "items")
+    item_pages = _attr(items_block, "pages") or []
+    page_to_items: dict[int, list[Any]] = {}
+    for page in item_pages:
+        pn = int(_attr(page, "page_number") or 0)
+        page_to_items[pn] = list(_attr(page, "items") or [])
+
+    new_anchors = list(anchors)
+    new_assignments = list(assignments)
+
+    for ent in sorted(layout_entries, key=lambda e: e.index):
+        if ent.index in assigned_idx:
+            continue
+        page_items = page_to_items.get(ent.page) or []
+        cap_items = collect_caption_labeled_items(page_items)
+        entry_bottom = ent.rect[1] + ent.rect[3]
+        ex0, ex1 = ent.rect[0], ent.rect[0] + ent.rect[2]
+        best: tuple[str, float] | None = None  # (caption_text, gap)
+        for txt, crect in cap_items:
+            _fl, fn = _parse_figure_label(txt)
+            if fn is None:
+                continue
+            cy = crect[1]
+            if cy <= entry_bottom:
+                continue
+            gap = cy - entry_bottom
+            if gap > _RESCUE_CAPTION_MAX_GAP_PX:
+                continue
+            if not _horizontal_overlap_positive(ent.rect, crect):
+                continue
+            if best is None or gap < best[1]:
+                best = (txt, gap)
+        if best is None:
+            continue
+        caption_text = best[0]
+        fl, fn = _parse_figure_label(caption_text)
+        synthetic = FigureAnchor(
+            page_number=ent.page,
+            alt="",
+            url=f"__layout_rescue_idx_{ent.index}__",
+            anchor_rect=ent.rect,
+            vlm_caption="",
+            mermaid_fence="",
+            source_caption=caption_text,
+            figure_label=fl,
+            figure_number=fn,
+            identity_signal="rescued_orphan",
+            from_image_item=False,
+        )
+        new_anchors.append(synthetic)
+        new_assignments.append([ent])
+        assigned_idx.add(ent.index)
+
+    return new_anchors, new_assignments
 
 
 def panel_role(n_panels: int, panel_index: int, rects: list[tuple[float, float, float, float]]) -> str | None:

--- a/src/processing/document/schema.py
+++ b/src/processing/document/schema.py
@@ -12,9 +12,17 @@ class ExtractedImage:
         mime_type: The MIME type of the image (e.g., image/png)
         base64_data: The raw base64 encoded string of the image
         page: 1-indexed page number where the image was found
-        caption: Extracted caption text associated with the figure (from ImageItem.caption)
+        caption: Paper/source caption (e.g. from LlamaParse caption-labeled text); stored as images.caption in DB
         storage_path: Path/URL where the image file is stored (local path or cloud URL)
         contextualized_text: Succinct context situated within the document
+        vlm_caption: Provider/VLM image description when distinct from paper caption (LlamaParse item.caption)
+        mermaid: Optional Mermaid transcription of the figure (same row as first panel only for multi-panel figures)
+        figure_group_id: Stable id shared by all panels of one figure
+        figure_label: Parsed label e.g. "Figure 2"
+        figure_number: Parsed figure index
+        panel_index: 0-based panel order within the figure (geometry-sorted)
+        panel_role: Optional spatial hint e.g. left, right
+        identity_signal: Which signal supplied figure identity (caption_item, markdown_alt, weak)
     """
     id: str
     """Unique artifact identifier (provider-prefixed, e.g., doc_lp_img_001)"""
@@ -28,6 +36,14 @@ class ExtractedImage:
     source_filename: str | None = None
     confidence: float | None = None
     category: str | None = None
+    vlm_caption: str = ""
+    mermaid: str | None = None
+    figure_group_id: str | None = None
+    figure_label: str | None = None
+    figure_number: int | None = None
+    panel_index: int | None = None
+    panel_role: str | None = None
+    identity_signal: str | None = None
 
 
 @dataclass

--- a/src/processing/document/schema.py
+++ b/src/processing/document/schema.py
@@ -24,6 +24,10 @@ class ExtractedImage:
     caption: str = ""
     storage_path: str | None = None
     contextualized_text: str | None = None
+    bbox: dict[str, Any] | None = None
+    source_filename: str | None = None
+    confidence: float | None = None
+    category: str | None = None
 
 
 @dataclass

--- a/src/processing/document/schema.py
+++ b/src/processing/document/schema.py
@@ -22,7 +22,8 @@ class ExtractedImage:
         figure_number: Parsed figure index
         panel_index: 0-based panel order within the figure (geometry-sorted)
         panel_role: Optional spatial hint e.g. left, right
-        identity_signal: Which signal supplied figure identity (caption_item, markdown_alt, weak)
+        identity_signal: Which signal supplied figure identity (caption_item, markdown_alt, weak,
+            rescued_orphan, layout_only)
     """
     id: str
     """Unique artifact identifier (provider-prefixed, e.g., doc_lp_img_001)"""


### PR DESCRIPTION
prepend number before output filename to keep temporal track
added version numbers for llama-cloud in requirements
added all image metadata to research.db, there were some missing
an involved process to match images in storage table to place in markdown text, based on IoU of their bbox values
added tests/ folder to gitignore
figure assignment works even on orphaned tables and not work on captionless images
litellm config cleaned up, using order and usage-based routing
Regex matches FIG in addition to Figure for captions