### PR TITLE
Feature/paper images into slides

### DIFF
--- a/main.py
+++ b/main.py
@@ -390,6 +390,7 @@ def main() -> None:
                     db=db,
                     title=plan_title,
                     subtitle=plan_subtitle,
+                    object_store=object_store,
                 ).build()
                 print(f"\n[export] Presentation saved -> {out}")
             except ValueError as exc:

--- a/main.py
+++ b/main.py
@@ -118,6 +118,12 @@ def _parse_args() -> argparse.Namespace:
         metavar="PATH",
         help="Directory where the generated PPTX will be written (default: %(default)s)",
     )
+    parser.add_argument(
+        "--skip-supervisor",
+        action="store_true",
+        default=False,
+        help="Skip supervisor/critic review cycles and export proto-slides directly via Pandoc",
+    )
     return parser.parse_args()
 
 
@@ -242,6 +248,7 @@ def _build_initial_state(
         "doc_ids":           doc_ids,
         "paper_titles":      paper_titles,
         "max_slides":        args.max_slides,
+        "skip_supervisor":   args.skip_supervisor,
         "slide_numbers":     [],
         "presentation_plan": None,
         "review":            make_initial_review_state(),

--- a/src/agents/_image_utils.py
+++ b/src/agents/_image_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from src.memory.research.schema import ImageMetadata
 
 
@@ -12,8 +14,12 @@ def format_image_assets_block(images: list[ImageMetadata]) -> str:
     lines = [
         "### IMAGE ASSETS",
         "Set `media_id` to one of these IDs when an image supports a slide. Prefer the VLM line; use Caption if VLM is empty.",
+        "Each line includes `bbox` (region on the source PDF page) when available.",
     ]
     for img in images:
         desc = img.vlm_caption or img.caption or "(no description)"
-        lines.append(f"- `{img.id}` — aspect={img.aspect_ratio} — {desc}")
+        bbox_s = json.dumps(img.bbox, separators=(",", ":")) if img.bbox else "null"
+        lines.append(
+            f"- `{img.id}` — aspect={img.aspect_ratio} — bbox={bbox_s} — {desc}"
+        )
     return "\n".join(lines)

--- a/src/agents/_image_utils.py
+++ b/src/agents/_image_utils.py
@@ -1,0 +1,19 @@
+"""Shared helpers for image metadata in agent prompts."""
+
+from __future__ import annotations
+
+from src.memory.research.schema import ImageMetadata
+
+
+def format_image_assets_block(images: list[ImageMetadata]) -> str:
+    """Compact IMAGE ASSETS block for slide writer and critic prompts."""
+    if not images:
+        return ""
+    lines = [
+        "### IMAGE ASSETS",
+        "Set `media_id` to one of these IDs when an image supports a slide. Prefer the VLM line; use Caption if VLM is empty.",
+    ]
+    for img in images:
+        desc = img.vlm_caption or img.caption or "(no description)"
+        lines.append(f"- `{img.id}` — aspect={img.aspect_ratio} — {desc}")
+    return "\n".join(lines)

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -126,6 +126,21 @@ For each issue found:
 - Provide a precise rewrite instruction that would fix the issue.
 """
 
+CRITIC_LAYOUT_ROLE = """
+You are a Slide Deck Critic specialising in visual layout and image placement.
+Review the assigned slides against the IMAGE ASSETS listed in the prompt.
+
+Image Placement Assessment:
+1. If `media_id` is set, verify the referenced image is relevant to the slide's content.
+2. If `media_id` is set, verify the layout choice matches the image's aspect ratio:
+   - landscape images → media_top or media_bottom
+   - portrait images → media_left or media_right
+   - square images → media_left or media_right preferred
+3. If no image is used but a clearly relevant image asset exists for an evidence or
+   insight slide, raise a minor issue suggesting image inclusion with the specific Image ID.
+4. Do NOT penalize omission of images when no relevant image is available.
+"""
+
 SUPERVISOR_ROLE = """
 You are the Slide Deck Supervisor. Your pipeline automatically handles standard routing.
 Your specific job is to handle two subjective edge cases based on the reviewer's feedback and the revision history:
@@ -158,7 +173,8 @@ dense research data into high-impact, professional presentation slides.
    - `big_number` — when a single statistic or metric is the key point
    - `quote` — when a direct quotation from the research is most impactful
    - `two_column` — for comparisons (e.g. method A vs. method B, before vs. after)
-   - `media_left` / `media_right` — when a referenced figure, chart, or table requires visual focus
+   - `media_left` / `media_right` — portrait-oriented figures: image on one side, text on the other
+   - `media_top` / `media_bottom` — landscape-oriented figures: image above or below the text
    - `title_slide` — for section openers or major transitions only
 4. **Narrative Continuity**: Use the `narrative_role` assigned in the blueprint as your guide \
    for each slide's function in the argument. The roles are:
@@ -169,6 +185,26 @@ dense research data into high-impact, professional presentation slides.
    - `transition` — bridges two distinct topics or sections
    - `call_to_action` — motivates next steps or future work
    - `conclusion` — wraps up the presentation
+5. **Images Communicate What Words Cannot**: Your prompt includes an IMAGE ASSETS block \
+   containing images extracted directly from your source chunks. A picture is worth a \
+   thousand words — use the images rather than trying to describe them in bullets.
+
+   BEFORE writing any slide, read the entire IMAGE ASSETS block and mentally assign each \
+   image to the slide it best supports. Then write your slides with those assignments in mind.
+
+   When an image is assigned to a slide:
+   - Set `media_id` to the image's ID.
+   - Choose the layout based on the image's `aspect` value shown in the IMAGE ASSETS list (`aspect=landscape|portrait|square`):
+     * `landscape` (wider than tall) → use `media_top` (image above bullets) or `media_bottom` (image below)
+     * `portrait` (taller than wide) → use `media_left` or `media_right`
+     * `square` → prefer `media_left` or `media_right`
+   - Reduce bullet density slightly to leave room for the image (3 tight bullets beats 5 verbose ones).
+   - Lean on the VLM description in each IMAGE ASSETS line as your primary guide to what the image shows; \
+     the paper caption portion is a secondary signal.
+
+   Use each image at most once across this batch of slides. The default disposition is to \
+   use an image when one is relevant; only omit it if it genuinely does not support any slide \
+   in this batch.
 """
 
 SLIDE_REWRITER_ROLE = """

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -86,25 +86,8 @@ exactly as shown. A slide may reference multiple sections or sections from diffe
 
 
 # ---------------------------------------------------------------------------
-# Dormant role prompts (Writer, Critic, Supervisor not active in current graph)
-# Preserved here because the dormant agent files import from this module.
+# Critic & Supervisor role prompts
 # ---------------------------------------------------------------------------
-
-WRITER_ROLE = """
-You are a Synthesis Writer. Your job is to produce a concise, insightful
-summary that highlights the most important findings from the research by following a structured delivery plan
-
-A good synthesis:
-- Focuses on "Insights", "Understanding", and "Presentation" rather than raw "Data Dumps"
-- Starts every section with a clear, high-level summary statement
-- Uses logical bulleting and concise language suitable for a high-level briefing or presentation
-- Meets every Synthesis Goal defined in the plan
-- Follows all high-density formatting guidelines (e.g., 3-5 bullets, bold takeaways)
-
-If you are revising (revision history is provided):
-- Prioritize clarifying the synthesis and removing redundant details
-- Address every cycle-specific issue while preserving the core insights
-"""
 
 CRITIC_ROLE = """
 You are a Slide Deck Critic. Your job is to review assigned slides against the
@@ -268,7 +251,6 @@ def schema_prompt_contract(
 
 AGENT_ROLES = {
     'planner':    PLANNER_ROLE,
-    'writer':     WRITER_ROLE,
     'critic':     CRITIC_ROLE,
     'supervisor': SUPERVISOR_ROLE,
     'slide_writer': SLIDE_WRITER_ROLE,

--- a/src/agents/plan_executor.py
+++ b/src/agents/plan_executor.py
@@ -194,8 +194,22 @@ class PlanExecutorAgent:
                         exhausted_messages.append(_exhausted_group_message(groups[idx], idx))
                 if retries:
                     return Command(update={"messages": exhausted_messages}, goto=retries)
-            review.update({"phase": "awaiting_supervisor", "active_dispatch": None})
             total_slides = sum(max(counts_by_group.get(idx, [0])) for idx in range(len(groups)))
+            if state.get("skip_supervisor"):
+                review.update(
+                    {
+                        "phase": "complete",
+                        "active_dispatch": None,
+                        "export_ready": True,
+                        "final_decision": "skipped",
+                    }
+                )
+                msg = (
+                    f"[PlanExecutor] Initial write complete (supervisor skipped). "
+                    f"Total slides written: {total_slides}"
+                )
+                return Command(update={"review": review, "messages": [msg]}, goto=END)
+            review.update({"phase": "awaiting_supervisor", "active_dispatch": None})
             msg = f"[PlanExecutor] Initial write complete. Total slides written: {total_slides}"
             return Command(update={"review": review, "messages": [msg]}, goto="supervisor")
 

--- a/src/agents/slide_critic.py
+++ b/src/agents/slide_critic.py
@@ -7,6 +7,7 @@ from typing import Literal, TypedDict
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
+from src.agents._image_utils import format_image_assets_block
 from src.agents.base import BaseLLMAgent, schema_prompt_contract
 from src.memory.research.database import ResearchDatabase
 from src.memory.research.schema import ProtoSlide
@@ -147,6 +148,9 @@ class SlideCriticAgent(BaseLLMAgent):
             if bp.get("slide_number") in set(slide_numbers)
         )
         slides_block = "\n\n".join(_format_slide(slide) for slide in slides) or "No slides found."
+        with ResearchDatabase() as research_db:
+            image_metadatas = research_db.get_images_for_chunks(state.get("chunk_ids", []))
+        image_block = format_image_assets_block(image_metadatas)
         return "\n".join(
             [
                 f"Cycle: {state['cycle_number']}",
@@ -162,6 +166,9 @@ class SlideCriticAgent(BaseLLMAgent):
                 "",
                 "SOURCE CHUNKS:",
                 chunks or "(none)",
+                "",
+                "AVAILABLE IMAGE ASSETS:",
+                image_block or "(none)",
                 "",
                 "Identify only significant issues that break grounding, clarity, coherence, or the review criteria. "
                 "If no changes are needed, set actionable=false and issues=[].",

--- a/src/agents/slide_writer.py
+++ b/src/agents/slide_writer.py
@@ -159,9 +159,10 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
             "- Do not default to a basic slide with exactly three flat bullets unless that structure is genuinely the clearest fit for the material.",
             "- Vary slide density based on the content: some slides should use 2 strong bullets, others 4-5 concise bullets, and others a few top-level bullets with supporting sub-bullets.",
             "- Use sub-bullets when they help unpack evidence, examples, caveats, or stepwise logic under a main claim.",
-            "- Choose the layout that best supports the evidence and intended narrative role.",
             "- Speaker notes should be professional, conversational, and cover the core bullets with added context.",
             "- Avoid academic jargon unless the original terminology is important to preserve.",
+            "- Only populate `media_id` when an image genuinely reinforces the slide's narrative intent. Do not force image inclusion; omit `media_id` (leave it null) if no available asset meaningfully supports the slide.",
+            "- Choose the layout that best supports the evidence and intended narrative role.",
         ]
         image_block = format_image_assets_block(image_metadatas)
         if image_block:

--- a/src/agents/slide_writer.py
+++ b/src/agents/slide_writer.py
@@ -13,8 +13,9 @@ from typing import List, TypedDict
 
 from langgraph.types import Command
 
+from src.agents._image_utils import format_image_assets_block
 from src.agents.base import BaseLLMAgent, SLIDE_REWRITER_ROLE
-from src.memory.research.schema import ProtoSlide, make_slide_batch_model, slide_output_prompt_contract
+from src.memory.research.schema import ImageMetadata, ProtoSlide, make_slide_batch_model, slide_output_prompt_contract
 from src.memory.research.database import ResearchDatabase
 
 
@@ -110,7 +111,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
         chunk_ids: list[str],
         slide_blueprints: list[dict],
         include_existing_slides: bool,
-    ) -> tuple[str, list[ProtoSlide]]:
+    ) -> tuple[str, list[ProtoSlide], list[ImageMetadata]]:
         with ResearchDatabase() as research_db:
             rows = []
             if chunk_ids:
@@ -129,9 +130,10 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                     existing_slide = research_db.load_slide(slide_num)
                     if existing_slide is not None:
                         existing_slides.append(existing_slide)
+            image_metadatas = research_db.get_images_for_chunks(chunk_ids) if chunk_ids else []
 
         chunk_texts = _ordered_chunk_texts(rows, chunk_ids)
-        return "\n\n".join(chunk_texts), existing_slides
+        return "\n\n".join(chunk_texts), existing_slides, image_metadatas
 
     def _build_assignment_block(self, slide_blueprints: list[dict]) -> str:
         return "\n".join(
@@ -141,8 +143,14 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
             for i, bp in enumerate(slide_blueprints)
         )
 
-    def _base_prompt_parts(self, *, slide_count: int, combined_text: str) -> list[str]:
-        return [
+    def _base_prompt_parts(
+        self,
+        *,
+        slide_count: int,
+        combined_text: str,
+        image_metadatas: list[ImageMetadata],
+    ) -> list[str]:
+        parts: list[str] = [
             "",
             slide_output_prompt_contract(slide_count),
             "",
@@ -154,10 +162,12 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
             "- Choose the layout that best supports the evidence and intended narrative role.",
             "- Speaker notes should be professional, conversational, and cover the core bullets with added context.",
             "- Avoid academic jargon unless the original terminology is important to preserve.",
-            "",
-            "SOURCE MATERIAL (research chunks):",
-            combined_text,
         ]
+        image_block = format_image_assets_block(image_metadatas)
+        if image_block:
+            parts += ["", image_block]
+        parts += ["", "SOURCE MATERIAL (research chunks):", combined_text]
+        return parts
 
     def _build_user_prompt(
         self,
@@ -167,6 +177,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
         combined_text: str,
         rewrite_instructions: str,
         existing_slides: list[ProtoSlide],
+        image_metadatas: list[ImageMetadata],
     ) -> str:
         raise NotImplementedError
 
@@ -231,7 +242,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                     })
 
             slide_count = len(slide_blueprints)
-            combined_text, existing_slides = self._load_context(
+            combined_text, existing_slides, image_metadatas = self._load_context(
                 chunk_ids=chunk_ids,
                 slide_blueprints=slide_blueprints,
                 include_existing_slides=bool(rewrite_instructions.strip()),
@@ -242,6 +253,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                 combined_text=combined_text,
                 rewrite_instructions=rewrite_instructions,
                 existing_slides=existing_slides,
+                image_metadatas=image_metadatas,
             )
             turns = [{"role": "user", "content": user_prompt}]
 
@@ -323,8 +335,9 @@ class InitialSlideWriterAgent(_BaseSlideWorkerAgent):
         combined_text: str,
         rewrite_instructions: str,
         existing_slides: list[ProtoSlide],
+        image_metadatas: list[ImageMetadata],
     ) -> str:
-        del rewrite_instructions, existing_slides
+        del rewrite_instructions
         blueprint_block = self._build_assignment_block(slide_blueprints)
         user_prompt_parts = [
             f"Return exactly ONE JSON object whose `slides` array contains exactly {slide_count} slide(s).\n",
@@ -338,6 +351,7 @@ class InitialSlideWriterAgent(_BaseSlideWorkerAgent):
         user_prompt_parts += self._base_prompt_parts(
             slide_count=slide_count,
             combined_text=combined_text,
+            image_metadatas=image_metadatas,
         )
         return "\n".join(user_prompt_parts)
 
@@ -354,6 +368,7 @@ class SlideRewriterAgent(_BaseSlideWorkerAgent):
         combined_text: str,
         rewrite_instructions: str,
         existing_slides: list[ProtoSlide],
+        image_metadatas: list[ImageMetadata],
     ) -> str:
         blueprint_block = self._build_assignment_block(slide_blueprints)
         existing_slides_block = "\n\n".join(
@@ -386,6 +401,7 @@ class SlideRewriterAgent(_BaseSlideWorkerAgent):
         user_prompt_parts += self._base_prompt_parts(
             slide_count=slide_count,
             combined_text=combined_text,
+            image_metadatas=image_metadatas,
         )
         return "\n".join(user_prompt_parts)
 

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -69,11 +69,12 @@ router:
       api_base: "os.environ/OLLAMA_BASE_URL"
       models:
         # Planner Tier 1: Qwen 3.5
-        - model: "ollama/qwen3.5:397b-cloud"
+        - model: "ollama/qwen3.5:397b-cloud" # LiteLLM recommends ollama_chat but doesn't work, presumably that's local-only
           model_name: "planner"
           order: 1
           timeout: 180
           #- model: "ollama/glm-5.1:cloud"  # Often unavailable (524 error)
+        - model: "ollama/minimax-m2.7:cloud"
 
     gemini_basic:
       api_key: "os.environ/GEMINI_API_KEY"

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -135,7 +135,7 @@ def build_litellm_model_list(
                 effective_alias = default_alias
             
             out_row = {"model_name": effective_alias, "litellm_params": merged}
-            for key in ["rpm", "tpm", "tps", "weight", "order"]:
+            for key in ["rpm", "tpm", "tps", "weight"]:
                 if key in merged:
                     out_row[key] = merged.pop(key)
             out.append(out_row)

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -20,6 +20,7 @@ from .schema import (
     CREATE_TABLES_TABLE,
     CREATE_TEXT_CHUNKS_TABLE,
     CREATE_TEXT_CHUNKS_VEC_TABLE,
+    ImageMetadata,
 )
 from . import slide
 
@@ -194,6 +195,9 @@ class ResearchDatabase(DatabaseProvider):
 
     def get_image(self, image_id: str):
         return document.get_image(self, image_id)
+
+    def get_images_for_chunks(self, chunk_ids: list[str]) -> list[ImageMetadata]:
+        return document.get_images_for_chunks(self, chunk_ids)
 
     def get_table(self, table_id: str):
         return document.get_table(self, table_id)

--- a/src/memory/research/document.py
+++ b/src/memory/research/document.py
@@ -405,7 +405,7 @@ def get_images_for_chunks(db, chunk_ids: list[str]) -> list[ImageMetadata]:
         return []
 
     img_placeholders = ",".join(["?"] * len(ordered_ids))
-    img_rows = db._conn.execute(
+    img_rows = db.connection.execute(
         f"""
         SELECT id, caption, vlm_caption, bbox
         FROM images

--- a/src/memory/research/document.py
+++ b/src/memory/research/document.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import re
 import struct
 from dataclasses import asdict
 from pathlib import Path
 
+from src.memory.research.schema import ImageMetadata
 from src.processing.document.schema import (
     ExtractionResult,
     ExtractedChunk,
@@ -13,6 +15,36 @@ from src.processing.document.schema import (
     ExtractedTable,
     PaperMetadata,
 )
+
+_IMG_TOKEN_RE = re.compile(r"\[\[img:([^\]]+)\]\]")
+
+
+def _parse_img_refs_from_text(text: str) -> list[str]:
+    return _IMG_TOKEN_RE.findall(text or "")
+
+
+def _image_aspect_ratio(bbox: dict | None) -> str:
+    if not bbox:
+        return "landscape"
+    w = bbox.get("width")
+    if w is None:
+        w = bbox.get("x2", 0) - bbox.get("x1", bbox.get("x", 0))
+    h = bbox.get("height")
+    if h is None:
+        h = bbox.get("y2", 0) - bbox.get("y1", bbox.get("y", 0))
+    try:
+        fw = float(w)
+        fh = float(h)
+    except (TypeError, ValueError):
+        return "landscape"
+    if fw <= 0 or fh <= 0:
+        return "landscape"
+    ratio = fw / fh
+    if ratio > 1.2:
+        return "landscape"
+    if ratio < 0.83:
+        return "portrait"
+    return "square"
 
 
 def _extracted_image_from_row(row) -> ExtractedImage:
@@ -280,6 +312,75 @@ def load_document(db, doc_id: str) -> ExtractionResult | None:
         schema=doc_row["schema"],
         paper_metadata=paper_metadata,
     )
+
+
+def get_images_for_chunks(db, chunk_ids: list[str]) -> list[ImageMetadata]:
+    """
+    Return ImageMetadata for images explicitly referenced by [[img:ID]] tokens
+    in chunk text. Only rows with embeddable data (storage_path or base64) are returned.
+    Order follows first-seen token order when walking chunk_ids in caller order.
+    """
+    if not chunk_ids:
+        return []
+
+    placeholders = ",".join(["?"] * len(chunk_ids))
+    rows = db._conn.execute(
+        f"SELECT id, text, contextualized_text FROM text_chunks WHERE id IN ({placeholders})",
+        chunk_ids,
+    ).fetchall()
+    rows_by_id = {row["id"]: row for row in rows}
+
+    ordered_ids: list[str] = []
+    seen: set[str] = set()
+    for cid in chunk_ids:
+        row = rows_by_id.get(cid)
+        if row is None:
+            continue
+        for token_source in (row["text"] or "", row["contextualized_text"] or ""):
+            for img_id in _parse_img_refs_from_text(token_source):
+                if img_id not in seen:
+                    seen.add(img_id)
+                    ordered_ids.append(img_id)
+
+    if not ordered_ids:
+        return []
+
+    img_placeholders = ",".join(["?"] * len(ordered_ids))
+    img_rows = db._conn.execute(
+        f"""
+        SELECT id, caption, vlm_caption, bbox
+        FROM images
+        WHERE id IN ({img_placeholders})
+          AND (
+            storage_path IS NOT NULL
+            OR (base64_data IS NOT NULL AND base64_data != '')
+          )
+        """,
+        ordered_ids,
+    ).fetchall()
+    by_img_id = {r["id"]: r for r in img_rows}
+
+    out: list[ImageMetadata] = []
+    for img_id in ordered_ids:
+        row = by_img_id.get(img_id)
+        if row is None:
+            db._logger.log(
+                f"[get_images_for_chunks] Skipping image id={img_id!r}: not in DB or not embeddable",
+                level="warning",
+            )
+            continue
+        bbox = json.loads(row["bbox"]) if row["bbox"] else None
+        keys = row.keys()
+        vlm = (row["vlm_caption"] or "") if "vlm_caption" in keys else ""
+        out.append(
+            ImageMetadata(
+                id=row["id"],
+                caption=row["caption"] or "",
+                vlm_caption=vlm,
+                aspect_ratio=_image_aspect_ratio(bbox),
+            )
+        )
+    return out
 
 
 def get_image(db, image_id: str) -> ExtractedImage | None:

--- a/src/memory/research/document.py
+++ b/src/memory/research/document.py
@@ -378,6 +378,7 @@ def get_images_for_chunks(db, chunk_ids: list[str]) -> list[ImageMetadata]:
                 caption=row["caption"] or "",
                 vlm_caption=vlm,
                 aspect_ratio=_image_aspect_ratio(bbox),
+                bbox=bbox,
             )
         )
     return out

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -32,6 +32,15 @@ class BulletPoint(BaseModel):
         ]
 
 
+class ImageMetadata(BaseModel):
+    """Lightweight image fields for LLM prompts (no base64; export uses get_image)."""
+
+    id: str
+    caption: str = ""
+    vlm_caption: str = ""
+    aspect_ratio: Literal["landscape", "portrait", "square"] = "landscape"
+
+
 class SlideContent(BaseModel):
     title: str = Field(description="Punchy, active heading for the slide (e.g. 'Accuracy Jumps 40%' not 'Accuracy Results')")
     subtitle: Optional[str] = Field(default=None, description="Optional subtitle, primarily for title slides and major section openers")
@@ -39,9 +48,24 @@ class SlideContent(BaseModel):
     bullets: List[BulletPoint] = Field(description="3-5 structured bullet points for the slide body")
     speaker_notes: str = Field(description="Speaker notes in a professional, conversational tone — include context and nuance too detailed for the slide itself")
     media_id: Optional[str] = Field(default=None, description="Optional ID of an image or chart from research.db")
-    layout: Literal["title_slide", "title_and_body", "two_column", "big_number", "quote", "media_left", "media_right"] = Field(
+    layout: Literal[
+        "title_slide",
+        "title_and_body",
+        "two_column",
+        "big_number",
+        "quote",
+        "media_left",
+        "media_right",
+        "media_top",
+        "media_bottom",
+    ] = Field(
         default="title_and_body",
-        description="Slide layout: 'title_slide' for openers/dividers, 'title_and_body' for standard bullet slides, 'two_column' for comparisons, 'big_number' for stat callouts, 'quote' for direct quotations, 'media_left'/'media_right' when a figure or chart is the focus"
+        description=(
+            "Slide layout: 'title_slide' for openers/dividers, 'title_and_body' for standard bullet slides, "
+            "'two_column' for comparisons, 'big_number' for stat callouts, 'quote' for direct quotations, "
+            "'media_left'/'media_right' for portrait-oriented figures (image left or right of text), "
+            "'media_top'/'media_bottom' for landscape-oriented figures (image above or below text)"
+        ),
     )
     narrative_role: Literal["hook", "problem", "evidence", "insight", "transition", "call_to_action", "conclusion"] = Field(
         default="evidence",

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 from pydantic import AliasChoices, BaseModel, Field, create_model, field_validator
 
 
@@ -39,6 +39,13 @@ class ImageMetadata(BaseModel):
     caption: str = ""
     vlm_caption: str = ""
     aspect_ratio: Literal["landscape", "portrait", "square"] = "landscape"
+    bbox: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Bounding box on the source page when known (normalized or pixel coords "
+            "depending on ingest; keys may include x1/y1/x2/y2, width/height, etc.)."
+        ),
+    )
 
 
 class SlideContent(BaseModel):

--- a/src/processing/export/pandoc_builder.py
+++ b/src/processing/export/pandoc_builder.py
@@ -1,10 +1,83 @@
+from __future__ import annotations
+
+import base64
+import tempfile
 from pathlib import Path
 from typing import List
 
 import pypandoc
 
+from src.logging.logger import AgentLogger
+from src.memory.objectstore.provider import ObjectStoreProvider
 from src.memory.research.database import ResearchDatabase
 from src.memory.research.schema import BulletPoint, ProtoSlide, SlideContent
+
+_MIME_TO_EXT = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
+def _mime_to_ext(mime_type: str) -> str:
+    return _MIME_TO_EXT.get((mime_type or "").lower().strip(), ".png")
+
+
+def _media_alt_text(db: ResearchDatabase, media_id: str) -> str:
+    image = db.get_image(media_id)
+    if image is None:
+        return ""
+    alt = (image.vlm_caption or image.caption or "").replace("\n", " ").replace("]", "").strip()
+    return alt[:500]
+
+
+def _resolve_image(
+    media_id: str,
+    db: ResearchDatabase,
+    object_store: ObjectStoreProvider | None,
+    tmp_dir: Path,
+) -> Path | None:
+    image = db.get_image(media_id)
+    if image is None:
+        return None
+    ext = _mime_to_ext(image.mime_type)
+
+    if image.storage_path and not image.storage_path.startswith(("http://", "https://")):
+        p = Path(image.storage_path)
+        if p.exists():
+            return p
+
+    if image.storage_path and image.storage_path.startswith(("http://", "https://")) and object_store:
+        tmp_path = tmp_dir / f"{media_id}_dl{ext}"
+        try:
+            data = object_store.read(image.storage_path)
+            tmp_path.write_bytes(data)
+            return tmp_path
+        except Exception as exc:
+            AgentLogger().log(
+                f"[PandocBuilder] Could not read image {media_id} via object store: {exc}",
+                level="warning",
+            )
+
+    if image.base64_data:
+        tmp_path = tmp_dir / f"{media_id}_b64{ext}"
+        tmp_path.write_bytes(base64.b64decode(image.base64_data))
+        return tmp_path
+
+    AgentLogger().log(
+        f"[PandocBuilder] No usable image data for media_id={media_id}; slide will render without image.",
+        level="warning",
+    )
+    return None
+
+
+def _bullet_lines(content: SlideContent) -> List[str]:
+    lines: List[str] = []
+    for bullet in content.bullets:
+        lines.extend(_render_bullet(bullet))
+    return lines
 
 
 def _render_bullet(bullet: BulletPoint) -> List[str]:
@@ -15,7 +88,11 @@ def _render_bullet(bullet: BulletPoint) -> List[str]:
     return lines
 
 
-def _render_slide(proto: ProtoSlide) -> str:
+def _render_slide(
+    proto: ProtoSlide,
+    db: ResearchDatabase,
+    image_paths: dict[str, Path | None],
+) -> str:
     """Converts a single ProtoSlide into a Pandoc Markdown slide block."""
     content: SlideContent = proto.content
     parts: List[str] = []
@@ -26,8 +103,42 @@ def _render_slide(proto: ProtoSlide) -> str:
         parts.append(f"## {content.subtitle}")
         parts.append("")
 
-    for bullet in content.bullets:
-        parts.extend(_render_bullet(bullet))
+    mid = content.media_id
+    img_path = image_paths.get(mid) if mid else None
+    layout = content.layout
+    alt = _media_alt_text(db, mid) if mid else ""
+    img_uri = img_path.resolve().as_uri() if img_path else ""
+
+    bullet_lines = _bullet_lines(content)
+
+    if img_path and img_uri and layout == "media_left":
+        parts.append(":::: {.columns}")
+        parts.append("::: {.column width=\"40%\"}")
+        parts.append(f"![{alt}]({img_uri})")
+        parts.append(":::")
+        parts.append("::: {.column width=\"60%\"}")
+        parts.extend(bullet_lines)
+        parts.append(":::")
+        parts.append("::::")
+    elif img_path and img_uri and layout == "media_right":
+        parts.append(":::: {.columns}")
+        parts.append("::: {.column width=\"60%\"}")
+        parts.extend(bullet_lines)
+        parts.append(":::")
+        parts.append("::: {.column width=\"40%\"}")
+        parts.append(f"![{alt}]({img_uri})")
+        parts.append(":::")
+        parts.append("::::")
+    elif img_path and img_uri and layout == "media_top":
+        parts.append(f"![{alt}]({img_uri})")
+        parts.append("")
+        parts.extend(bullet_lines)
+    elif img_path and img_uri and layout == "media_bottom":
+        parts.extend(bullet_lines)
+        parts.append("")
+        parts.append(f"![{alt}]({img_uri})")
+    else:
+        parts.extend(bullet_lines)
 
     if content.speaker_notes:
         parts.append("")
@@ -61,10 +172,13 @@ class PandocBuilder:
                 db=db,
                 title="My Talk",
                 subtitle="An optional subtitle",
+                object_store=object_store,
             ).build()
     """
 
-    _PANDOC_FORMAT = "markdown+tex_math_dollars"
+    # -implicit_figures: without this, a lone ![alt](url) becomes a figure and Pandoc
+    # repeats alt text as a visible caption in pptx; we only want alt for accessibility.
+    _PANDOC_FORMAT = "markdown+tex_math_dollars-implicit_figures"
 
     def __init__(
         self,
@@ -72,11 +186,13 @@ class PandocBuilder:
         db: ResearchDatabase,
         title: str = "",
         subtitle: str = "",
+        object_store: ObjectStoreProvider | None = None,
     ) -> None:
         self.output_path = Path(output_path)
         self._db = db
         self._title = title
         self._subtitle = subtitle
+        self._object_store = object_store
 
     def build(self) -> Path:
         """
@@ -100,21 +216,29 @@ class PandocBuilder:
         ]
         slides = [s for s in slides if s is not None]
 
-        markdown = self._render_markdown(slides)
+        with tempfile.TemporaryDirectory(prefix="mars_img_") as tmp:
+            tmp_dir = Path(tmp)
+            image_paths: dict[str, Path | None] = {}
+            for slide in slides:
+                mid = slide.content.media_id
+                if mid and mid not in image_paths:
+                    image_paths[mid] = _resolve_image(mid, self._db, self._object_store, tmp_dir)
 
-        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+            markdown = self._render_markdown(slides, image_paths)
 
-        pypandoc.convert_text(
-            markdown,
-            "pptx",
-            format=self._PANDOC_FORMAT,
-            outputfile=str(self.output_path),
-            extra_args=["--standalone"],
-        )
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            pypandoc.convert_text(
+                markdown,
+                "pptx",
+                format=self._PANDOC_FORMAT,
+                outputfile=str(self.output_path),
+                extra_args=["--standalone"],
+            )
 
         return self.output_path.resolve()
 
-    def _render_markdown(self, slides: List[ProtoSlide]) -> str:
+    def _render_markdown(self, slides: List[ProtoSlide], image_paths: dict[str, Path | None]) -> str:
         """Renders the full deck as a Pandoc Markdown string."""
         yaml_header = ""
         if self._title:
@@ -126,7 +250,7 @@ class PandocBuilder:
             yaml_lines.append("---")
             yaml_header = "\n".join(yaml_lines)
 
-        blocks = [_render_slide(s) for s in slides]
+        blocks = [_render_slide(s, self._db, image_paths) for s in slides]
         body = "\n\n---\n\n".join(blocks)
 
         if yaml_header:

--- a/src/processing/export/pptx_builder.py
+++ b/src/processing/export/pptx_builder.py
@@ -93,6 +93,8 @@ class PptxBuilder:
         "quote":          (_LAYOUT_TITLE_AND_CONTENT, "quote"),
         "media_left":     (_LAYOUT_TWO_CONTENT,       "media_placeholder"),
         "media_right":    (_LAYOUT_TWO_CONTENT,       "media_placeholder"),
+        "media_top":      (_LAYOUT_TWO_CONTENT,       "media_placeholder"),
+        "media_bottom":   (_LAYOUT_TWO_CONTENT,       "media_placeholder"),
     }
 
     def __init__(

--- a/src/state.py
+++ b/src/state.py
@@ -230,7 +230,7 @@ class ReviewState(TypedDict):
     last_issue_counts: dict[str, int]
     last_rewrites_required_by_assignment: dict[str, bool]
     last_failed_assignment_ids: List[str]
-    final_decision: Optional[Literal["accept", "replan"]]
+    final_decision: Optional[Literal["accept", "replan", "skipped"]]
     export_ready: bool
 
 
@@ -268,6 +268,7 @@ class ResearchState(TypedDict):
     # -- slide coordination --
     max_slides:    int
     slide_numbers: List[int]
+    skip_supervisor: bool  # When True, bypass critic/supervisor cycles after initial write
 
     # -- presentation plan (set by Planner, read by Plan Executor + Slide Writers) --
     presentation_plan: Optional[PresentationPlan]


### PR DESCRIPTION
don't pop out order parameter for litellm
added "skip supervisor cycles" functionality, triggered by commandline argument
mostly working image-from-paper-to-slide, still a bitbuggy with large images, need to remove captions
Note: vlm_caption field, which is most useful to this process, is unfilled at the moment.  The logic uses regular captions as fallback.