### PR TITLE
Fix/affected slides pass replan refactor

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,8 @@ OLLAMA_BASE_URL=https://ollama.com
 GEMINI_API_KEY=your_key_here
 ANTHROPIC_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
+GROQ_API_KEY=your_key_here
+MISTRAL_API_KEY=your_key_here
 LLAMA_CLOUD_API_KEY=your_key_here
 
 LANGFUSE_SECRET_KEY=sk-lf-...

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ data/
 output/
 validation_errors/
 scratch/
-tests/

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,5 +1,6 @@
 import json
 import time
+from contextvars import ContextVar
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Any, TypeVar
@@ -21,6 +22,9 @@ from src.tools.registry import execute_tool_call, get_tool_prompt_snippets, get_
 from src.tools.rag import format_tool_result_for_llm
 
 T = TypeVar("T", bound=BaseModel)
+
+# Propagated from slide writer / critic dispatch state so RAG can tag retrieval rows by plan.
+current_plan_generation: ContextVar[int] = ContextVar("current_plan_generation", default=0)
 
 
 @dataclass
@@ -302,6 +306,14 @@ class BaseLLMAgent:
         sid = state.get("session_id") if isinstance(state, dict) else None
         if sid:
             current_session_id.set(sid)
+
+    def _set_plan_generation(self, state: dict) -> None:
+        """Tag tool execution with the active presentation plan generation (replan epoch)."""
+        if not isinstance(state, dict):
+            return
+        g = state.get("plan_generation")
+        if g is not None:
+            current_plan_generation.set(int(g))
 
     def _build_messages(
         self,
@@ -712,6 +724,7 @@ class BaseLLMAgent:
                     context={
                         "session_id": session_id,
                         "agent_type": self.role,
+                        "plan_generation": current_plan_generation.get(),
                     },
                 )
 

--- a/src/agents/plan_executor.py
+++ b/src/agents/plan_executor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from langgraph.graph import END
 from langgraph.types import Command, Send
 
+from src.memory.research.database import ResearchDatabase
 from src.state import PresentationPlan, ResearchState, SlideGroup
 
 MAX_RETRIES_PER_GROUP = 2
@@ -41,6 +42,7 @@ def _build_slide_writer_send(
     group: SlideGroup,
     group_idx: int,
     session_id: str,
+    plan_generation: int = 0,
     rewrite_instructions: str = "",
     target_slide_numbers: list[int] | None = None,
 ) -> Send:
@@ -49,6 +51,7 @@ def _build_slide_writer_send(
         {
             "dispatch_id":        dispatch_id,
             "assignment_id":      assignment_id,
+            "plan_generation":   plan_generation,
             "chunk_ids":          _group_chunk_ids(group),
             "slide_blueprints":   _blueprints_as_dicts(group),
             "group_idx":          group_idx,
@@ -65,6 +68,7 @@ def _build_critic_send(*, dispatch_id: str, session_id: str, assignment: dict) -
         {
             "dispatch_id": dispatch_id,
             "assignment_id": assignment["assignment_id"],
+            "plan_generation": assignment["plan_generation"],
             "cycle_number": assignment["cycle_number"],
             "session_id": session_id,
             "check_type": assignment["check_type"],
@@ -114,6 +118,7 @@ class PlanExecutorAgent:
         slides_written:    list[dict]               = state.get("slides_written", [])
         critic_results:    list[dict]               = state.get("critic_results", [])
         review = dict(state.get("review") or {})
+        plan_generation = int(review.get("plan_generation", 0))
 
         if presentation_plan is None:
             raise ValueError("[PlanExecutor] No presentation_plan in state.")
@@ -124,6 +129,13 @@ class PlanExecutorAgent:
         active_dispatch = review.get("active_dispatch")
 
         if phase == "initial_write" and active_dispatch is None:
+            new_slide_numbers = [
+                bp.slide_number
+                for group in groups
+                for bp in group.slide_blueprints
+            ]
+            with ResearchDatabase() as research_db:
+                research_db.delete_slides_not_in(new_slide_numbers)
             self._logger.log(
                 f"[PlanExecutor] Initial dispatch — {len(groups)} group(s)"
             )
@@ -144,6 +156,7 @@ class PlanExecutorAgent:
                         group=group,
                         group_idx=idx,
                         session_id=session_id,
+                        plan_generation=plan_generation,
                     )
                 )
 
@@ -155,6 +168,7 @@ class PlanExecutorAgent:
                         "dispatch_id": dispatch_id,
                         "kind": "initial_write",
                         "cycle_number": 0,
+                        "plan_generation": plan_generation,
                         "expected_assignment_ids": [f"initial-g{idx}" for idx in range(len(groups))],
                     },
                 }
@@ -162,7 +176,13 @@ class PlanExecutorAgent:
             return Command(update={"review": review}, goto=sends)
 
         if phase == "initial_write" and active_dispatch is not None:
-            relevant = [entry for entry in slides_written if entry.get("dispatch_id") == active_dispatch["dispatch_id"]]
+            ag = active_dispatch.get("plan_generation", 0)
+            relevant = [
+                entry
+                for entry in slides_written
+                if entry.get("dispatch_id") == active_dispatch["dispatch_id"]
+                and entry.get("plan_generation", 0) == ag
+            ]
             if len(relevant) < len(active_dispatch["expected_assignment_ids"]):
                 return Command(update={})
             counts_by_group: dict[int, list[int]] = {}
@@ -188,6 +208,7 @@ class PlanExecutorAgent:
                                 group=groups[idx],
                                 group_idx=idx,
                                 session_id=session_id,
+                                plan_generation=ag,
                             )
                         )
                     else:
@@ -228,6 +249,7 @@ class PlanExecutorAgent:
                             "dispatch_id": dispatch_id,
                             "kind": "critic",
                             "cycle_number": review.get("cycle_number", 0),
+                            "plan_generation": plan_generation,
                             "expected_assignment_ids": [assignment["assignment_id"] for assignment in assignments],
                         },
                     }
@@ -235,9 +257,12 @@ class PlanExecutorAgent:
                 return Command(update={"review": review}, goto=sends)
 
             if active_dispatch:
+                adg = active_dispatch.get("plan_generation", 0)
                 relevant_results = [
-                    result for result in critic_results
+                    result
+                    for result in critic_results
                     if result.get("dispatch_id") == active_dispatch["dispatch_id"]
+                    and result.get("plan_generation", 0) == adg
                 ]
                 if len(relevant_results) < len(active_dispatch["expected_assignment_ids"]):
                     return Command(update={})
@@ -269,6 +294,7 @@ class PlanExecutorAgent:
                             group=groups[group_idx],
                             group_idx=group_idx,
                             session_id=session_id,
+                            plan_generation=plan_generation,
                             rewrite_instructions=assignment.get("rewrite_instructions", ""),
                             target_slide_numbers=assignment.get("target_slide_numbers", []),
                         )
@@ -280,6 +306,7 @@ class PlanExecutorAgent:
                             "dispatch_id": dispatch_id,
                             "kind": "rewrite",
                             "cycle_number": review.get("cycle_number", 0),
+                            "plan_generation": plan_generation,
                             "expected_assignment_ids": [assignment["assignment_id"] for assignment in assignments],
                         },
                     }
@@ -287,9 +314,12 @@ class PlanExecutorAgent:
                 return Command(update={"review": review}, goto=sends)
 
             if active_dispatch:
+                adg = active_dispatch.get("plan_generation", 0)
                 relevant_writes = [
-                    entry for entry in slides_written
+                    entry
+                    for entry in slides_written
                     if entry.get("dispatch_id") == active_dispatch["dispatch_id"]
+                    and entry.get("plan_generation", 0) == adg
                 ]
                 if len(relevant_writes) < len(active_dispatch["expected_assignment_ids"]):
                     return Command(update={})

--- a/src/agents/slide_critic.py
+++ b/src/agents/slide_critic.py
@@ -19,6 +19,7 @@ from src.state import (
 
 
 class CriticDispatch(TypedDict):
+    plan_generation: int
     dispatch_id: str
     assignment_id: str
     cycle_number: int
@@ -109,11 +110,15 @@ class SlideCriticAgent(BaseLLMAgent):
     def __init__(self, *, log_display: str | None = None) -> None:
         super().__init__("critic", log_display=log_display)
 
-    def _load_session_retrieval_log(self, session_id: str) -> str:
+    def _load_session_retrieval_log(
+        self, session_id: str, plan_generation: int | None = None
+    ) -> str:
         if not session_id:
             return ""
         with ResearchDatabase() as research_db:
-            rows = research_db.load_normalized_artifacts_for_session(session_id)
+            rows = research_db.load_normalized_artifacts_for_session(
+                session_id, plan_generation=plan_generation
+            )
         ordered: list[str] = []
         for row in rows:
             ordered.append(self._format_retrieved_artifact(row))
@@ -151,7 +156,10 @@ class SlideCriticAgent(BaseLLMAgent):
     def _build_user_prompt(self, state: CriticDispatch) -> str:
         slide_numbers = state.get("target_slide_numbers", [])
         slides = self._load_slides(slide_numbers)
-        retrieval_log = self._load_session_retrieval_log(state.get("session_id", ""))
+        plan_gen = int(state.get("plan_generation", 0))
+        retrieval_log = self._load_session_retrieval_log(
+            state.get("session_id", ""), plan_generation=plan_gen
+        )
         blueprints = state.get("slide_blueprints", [])
         blueprint_block = "\n".join(
             f"Slide {bp.get('slide_number')}: {bp.get('working_title', '')} — {bp.get('intent', '')}"
@@ -215,6 +223,8 @@ class SlideCriticAgent(BaseLLMAgent):
 
     def run(self, state: CriticDispatch) -> Command:
         self._set_session_id(state)
+        self._set_plan_generation(state)
+        plan_gen = int(state.get("plan_generation", 0))
         prompt = self._build_user_prompt(state)
         result: CriticOutput = self._call(
             [{"role": "user", "content": prompt}],
@@ -257,6 +267,7 @@ class SlideCriticAgent(BaseLLMAgent):
             _fmt_instruction(issue) for issue in issues if issue["rewrite_instruction"].strip()
         )
         critic_result: CriticResultRecord = {
+            "plan_generation": plan_gen,
             "dispatch_id": state["dispatch_id"],
             "assignment_id": state["assignment_id"],
             "cycle_number": state["cycle_number"],
@@ -279,6 +290,7 @@ class SlideCriticAgent(BaseLLMAgent):
                 research_db.save_review_event(
                     session_id=state["session_id"],
                     cycle_number=state["cycle_number"],
+                    plan_generation=plan_gen,
                     scope_type=state["scope_type"],
                     scope_id=state["scope_id"],
                     check_type=state["check_type"],
@@ -295,6 +307,7 @@ class SlideCriticAgent(BaseLLMAgent):
                 research_db.save_review_event(
                     session_id=state["session_id"],
                     cycle_number=state["cycle_number"],
+                    plan_generation=plan_gen,
                     scope_type=state["scope_type"],
                     scope_id=state["scope_id"],
                     check_type=state["check_type"],

--- a/src/agents/slide_critic.py
+++ b/src/agents/slide_critic.py
@@ -240,8 +240,21 @@ class SlideCriticAgent(BaseLLMAgent):
                     "rewrite_instruction": issue.rewrite_instruction,
                 }
             )
+        def _fmt_instruction(issue: dict) -> str:
+            slide_nums = issue.get("affected_slide_numbers") or []
+            loc = issue.get("location", "").strip()
+            
+            context_parts = []
+            if slide_nums:
+                context_parts.append(f"Slide(s) {', '.join(str(n) for n in slide_nums)}")
+            if loc and loc.lower() not in ("none", "n/a", "general", "all"):
+                context_parts.append(f"Location: {loc}")
+                
+            prefix = f"[{' | '.join(context_parts)}] " if context_parts else ""
+            return f"- {prefix}{issue['rewrite_instruction']}"
+
         rewrite_instructions = "\n".join(
-            f"- {issue['rewrite_instruction']}" for issue in issues if issue["rewrite_instruction"].strip()
+            _fmt_instruction(issue) for issue in issues if issue["rewrite_instruction"].strip()
         )
         critic_result: CriticResultRecord = {
             "dispatch_id": state["dispatch_id"],
@@ -272,6 +285,8 @@ class SlideCriticAgent(BaseLLMAgent):
                     assignment_id=state["assignment_id"],
                     issue_code=issue["issue_code"],
                     severity=issue["severity"],
+                    location=issue["location"],
+                    description=issue["description"],
                     fingerprint=issue["fingerprint"],
                     rewrite_instruction_summary=issue["rewrite_instruction"],
                     affected_slide_numbers=issue.get("affected_slide_numbers") or None,

--- a/src/agents/slide_writer.py
+++ b/src/agents/slide_writer.py
@@ -25,6 +25,7 @@ from src.memory.research.database import ResearchDatabase
 
 class SlideWriterDispatch(TypedDict):
     """State payload delivered to each slide_writer node via Send()."""
+    plan_generation: int
     dispatch_id:            str
     assignment_id:          str
     chunk_ids:             List[str]   # group-wide union passed to the writer as shared working context
@@ -89,6 +90,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
         self,
         error: Exception,
         *,
+        plan_generation: int,
         dispatch_id: str,
         assignment_id: str,
         group_idx: int,
@@ -100,6 +102,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
         err_msg = f"[{tag}] FAILED: {err_str}"
         return Command(update={
             "slides_written": [{
+                "plan_generation": plan_generation,
                 "dispatch_id": dispatch_id,
                 "assignment_id": assignment_id,
                 "group_idx": group_idx,
@@ -238,6 +241,8 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
 
     def run(self, state: SlideWriterDispatch) -> Command:
         self._set_session_id(state)
+        self._set_plan_generation(state)
+        plan_generation      = int(state.get("plan_generation", 0))
         chunk_ids            = state.get("chunk_ids", [])
         slide_blueprints     = state.get("slide_blueprints", [])
         group_idx            = state.get("group_idx", 0)
@@ -253,6 +258,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                 self._logger.log(f"[{tag}] No blueprints — skipping", level="warning")
                 return Command(update={
                     "slides_written": [{
+                        "plan_generation": plan_generation,
                         "dispatch_id": dispatch_id,
                         "assignment_id": assignment_id,
                         "group_idx": group_idx,
@@ -272,6 +278,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                     self._logger.log(f"[{tag}] No matching target slides — skipping", level="warning")
                     return Command(update={
                         "slides_written": [{
+                            "plan_generation": plan_generation,
                             "dispatch_id": dispatch_id,
                             "assignment_id": assignment_id,
                             "group_idx": group_idx,
@@ -312,6 +319,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
                 self._logger.log(f"[{tag}] No retrieved artifacts available for writing", level="warning")
                 return Command(update={
                     "slides_written": [{
+                        "plan_generation": plan_generation,
                         "dispatch_id": dispatch_id,
                         "assignment_id": assignment_id,
                         "group_idx": group_idx,
@@ -378,6 +386,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
 
             return Command(update={
                 "slides_written": [{
+                    "plan_generation": plan_generation,
                     "dispatch_id": dispatch_id,
                     "assignment_id": assignment_id,
                     "group_idx": group_idx,
@@ -393,6 +402,7 @@ class _BaseSlideWorkerAgent(BaseLLMAgent):
         except Exception as e:
             return self._failure(
                 e,
+                plan_generation=plan_generation,
                 dispatch_id=dispatch_id,
                 assignment_id=assignment_id,
                 group_idx=group_idx,

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from src.memory.research.database import ResearchDatabase
 from src.agents.base import BaseLLMAgent
-from src.state import MAX_CYCLES, ResearchState, ReviewAssignment
+from src.state import MAX_CYCLES, ResearchState, ReviewAssignment, make_initial_review_state
 
 
 # ---------------------------------------------------------------------------
@@ -81,12 +81,15 @@ def _all_actionable_issues_are_persistent_minor(
     return saw_issue
 
 
-def _build_group_assignments(*, plan, cycle_number: int) -> list[ReviewAssignment]:
+def _build_group_assignments(
+    *, plan, cycle_number: int, plan_generation: int
+) -> list[ReviewAssignment]:
     assignments: list[ReviewAssignment] = []
     for idx, group in enumerate(plan.slide_groups):
         target_slide_numbers = [bp.slide_number for bp in group.slide_blueprints]
         assignments.append(
             {
+                "plan_generation": plan_generation,
                 "assignment_id": f"critic-c{cycle_number}-g{idx}",
                 "cycle_number": cycle_number,
                 "check_type": "grounding_consistency",
@@ -126,7 +129,9 @@ def _short_reasoning(text: str, max_len: int = 240) -> str:
     return one_line[: max_len - 1] + "…"
 
 
-def _build_rewrite_assignments(*, plan, results: list[dict], cycle_number: int) -> list[ReviewAssignment]:
+def _build_rewrite_assignments(
+    *, plan, results: list[dict], cycle_number: int, plan_generation: int
+) -> list[ReviewAssignment]:
     assignments: list[ReviewAssignment] = []
     for result in results:
         group = plan.slide_groups[result["group_idx"]]
@@ -157,6 +162,7 @@ def _build_rewrite_assignments(*, plan, results: list[dict], cycle_number: int) 
 
         assignments.append(
             {
+                "plan_generation": plan_generation,
                 "assignment_id": f"rewrite-{result['assignment_id']}",
                 "cycle_number": cycle_number,
                 "check_type": result["check_type"],
@@ -184,17 +190,21 @@ class SupervisorAgent(BaseLLMAgent):
             raise ValueError("[Supervisor] No presentation_plan in state.")
 
         cycle_number = review.get("cycle_number", 0)
+        plan_generation = review.get("plan_generation", 0)
         phase = review.get("phase", "awaiting_supervisor")
         critic_results = [
             result
             for result in state.get("critic_results", [])
             if result.get("cycle_number") == cycle_number
+            and result.get("plan_generation", 0) == plan_generation
         ]
         severity_counts = _severity_counts(critic_results)
         rewrites_required = _rewrite_map(critic_results)
         history = []
         with ResearchDatabase() as research_db:
-            history = research_db.list_review_events(state["session_id"])
+            history = research_db.list_review_events(
+                state["session_id"], plan_generation=plan_generation
+            )
         recurring = {}
         for event in history:
             fingerprint = event.get("fingerprint")
@@ -218,6 +228,7 @@ class SupervisorAgent(BaseLLMAgent):
             if cycle_number >= review.get("max_cycles", MAX_CYCLES) and review.get("last_rewrite_assignment_ids"):
                 review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
                 summary = {
+                    "plan_generation": plan_generation,
                     "cycle_number": cycle_number,
                     "issue_counts": review.get("last_issue_counts", {"critical": 0, "major": 0, "minor": 0}),
                     "decision": "accept",
@@ -237,7 +248,9 @@ class SupervisorAgent(BaseLLMAgent):
                     goto=END,
                 )
 
-            assignments = _build_group_assignments(plan=plan, cycle_number=next_cycle)
+            assignments = _build_group_assignments(
+                plan=plan, cycle_number=next_cycle, plan_generation=plan_generation
+            )
             review.update(
                 {
                     "cycle_number": next_cycle,
@@ -265,6 +278,7 @@ class SupervisorAgent(BaseLLMAgent):
             if cycle_number >= review.get("max_cycles", MAX_CYCLES):
                 review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
                 summary = {
+                    "plan_generation": plan_generation,
                     "cycle_number": cycle_number,
                     "issue_counts": severity_counts,
                     "decision": "accept",
@@ -285,7 +299,9 @@ class SupervisorAgent(BaseLLMAgent):
                 )
 
             next_cycle = cycle_number + 1
-            assignments = _build_group_assignments(plan=plan, cycle_number=next_cycle)
+            assignments = _build_group_assignments(
+                plan=plan, cycle_number=next_cycle, plan_generation=plan_generation
+            )
             review.update(
                 {
                     "cycle_number": next_cycle,
@@ -298,6 +314,7 @@ class SupervisorAgent(BaseLLMAgent):
                 }
             )
             summary = {
+                "plan_generation": plan_generation,
                 "cycle_number": cycle_number,
                 "issue_counts": severity_counts,
                 "decision": "revise",
@@ -360,6 +377,7 @@ class SupervisorAgent(BaseLLMAgent):
 
 
         summary = {
+            "plan_generation": plan_generation,
             "cycle_number": cycle_number,
             "issue_counts": severity_counts,
             "decision": decision,
@@ -383,17 +401,21 @@ class SupervisorAgent(BaseLLMAgent):
         )
 
         if decision == "replan":
-            review.update({"final_decision": "replan", "export_ready": False, "phase": "complete"})
-            updates["review"] = review
+            old_plan_generation = review.get("plan_generation", 0)
             with ResearchDatabase() as research_db:
                 research_db.save_review_event(
                     session_id=state["session_id"],
                     cycle_number=cycle_number,
+                    plan_generation=old_plan_generation,
                     scope_type="deck",
                     scope_id="deck",
                     check_type="grounding_consistency",
                     decision="replan",
                 )
+            new_review = make_initial_review_state(max_cycles=review.get("max_cycles", MAX_CYCLES))
+            new_review["dispatch_counter"] = review.get("dispatch_counter", 0)
+            new_review["plan_generation"] = old_plan_generation + 1
+            updates["review"] = new_review
             return Command(update=updates, goto="planner")
 
         if decision == "accept":
@@ -403,6 +425,7 @@ class SupervisorAgent(BaseLLMAgent):
                 research_db.save_review_event(
                     session_id=state["session_id"],
                     cycle_number=cycle_number,
+                    plan_generation=plan_generation,
                     scope_type="deck",
                     scope_id="deck",
                     check_type="grounding_consistency",
@@ -414,6 +437,7 @@ class SupervisorAgent(BaseLLMAgent):
             plan=plan,
             results=actionable_results,
             cycle_number=cycle_number,
+            plan_generation=plan_generation,
         )
         self._logger.log(
             f"[supervisor] dispatch {len(rewrite_assignments)} slide rewriter(s): "

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -137,6 +137,24 @@ def _build_rewrite_assignments(*, plan, results: list[dict], cycle_number: int) 
                 for cid in bp.source_chunk_ids
             )
         )
+        issues = result.get("issues", [])
+        valid_group_slides = set(result.get("target_slide_numbers", []))
+        
+        all_have_slide_numbers = bool(issues) and all(
+            issue.get("affected_slide_numbers") for issue in issues
+        )
+        
+        if all_have_slide_numbers:
+            affected = list(dict.fromkeys(
+                n for issue in issues for n in issue["affected_slide_numbers"]
+                if n in valid_group_slides
+            ))
+            # Fallback if the critic only hallucinated out-of-bounds slide numbers
+            if not affected:
+                affected = result.get("target_slide_numbers", [])
+        else:
+            affected = result.get("target_slide_numbers", [])
+
         assignments.append(
             {
                 "assignment_id": f"rewrite-{result['assignment_id']}",
@@ -147,7 +165,7 @@ def _build_rewrite_assignments(*, plan, results: list[dict], cycle_number: int) 
                 "group_idx": result["group_idx"],
                 "chunk_ids": chunk_ids,
                 "slide_blueprints": [bp.model_dump() for bp in group.slide_blueprints],
-                "target_slide_numbers": result.get("target_slide_numbers", []),
+                "target_slide_numbers": affected,
                 "rewrite_instructions": result.get("rewrite_instructions", ""),
             }
         )

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -12,7 +12,7 @@
 #
 # Current sample assumes free teir for Gemini, Ollama and OpenRouter.
 # Get available OpenRouter free models at https://openrouter.ai/collections/free-models (changes frequently).
-# See also https://github.com/mnfst/awesome-free-llm-apis (model lists likely outdated).  LiteLLM implements most of those.
+# See also https://github.com/mnfst/awesome-free-llm-apis (model lists likely outdated).  LiteLLM implements most of those (https://docs.litellm.ai/docs/providers).
 # A free OpenRouter account only gets 50 daily requests, adding minimum of 10 credits "verifies" your account and raises the daily limit to 1000 requests
 
 router:
@@ -37,6 +37,7 @@ router:
         - model: "gemini/gemini-3.1-flash-lite-preview"
           model_name: "slides"
           rpm: 15
+          
         - model: "gemini/gemini-3.1-flash-lite-preview"
           rpm: 15
           model_name: "fallback"
@@ -52,15 +53,15 @@ router:
         # Planner Tier 2: Nemotron 3 Super
         - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
           model_name: "planner"
-          order: 1
+          order: 2
         # Planner Tier 3: Elephant Alpha
         - model: "openrouter/inclusionai/ling-2.6-flash:free"   # Iffy structured output, constantly fails validation
           model_name: "planner"
           order: 3
-        # Critic first preference
-        - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+        # Critic preference
+        - model: "openrouter/inclusionai/ling-2.6-flash:free"
           model_name: "critic"
-          order: 2
+          order: 3
 
         - model: "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
 
@@ -72,17 +73,38 @@ router:
         - model: "ollama/qwen3.5:397b-cloud" # LiteLLM recommends ollama_chat but doesn't work, presumably that's local-only
           timeout: 240  # Increased from 180, Qwen 3.5 is slow
           model_name: "planner"
-          order: 2
-          #- model: "ollama/glm-5.1:cloud"  # Often unavailable (524 error)
+          order: 1
         - model: "ollama/minimax-m2.7:cloud"
+          model_name: "critic"
+          order: 2
+
+        - model: "ollama/minimax-m2.7:cloud"
+        #- model: "ollama/glm-5.1:cloud"  # Often unavailable (524 error)
+
+    mistral:
+      api_key: "os.environ/MISTRAL_API_KEY"
+      models:
+        - model: "mistral/mistral-large-latest"  # 1 RPS
           model_name: "critic"
           order: 1
 
-        - model: "ollama/minimax-m2.7:cloud"
+        - model: "mistral/mistral-large-latest"  # 1 RPS, vision-capable
+        - model: "mistral/magistral-medium-2508"  # Reasoning. Does it support structured output?
+          rpm: 20
+
+    groq:
+      api_key: "os.environ/GROQ_API_KEY"
+      models:
+        - model: "groq/openai/gpt-oss-120b"   # 8K TPM input might be too restrictive
+        - model: "groq/llama-3.3-70b-versatile" # 12K TPM
 
     gemini_basic:
       api_key: "os.environ/GEMINI_API_KEY"
       models:
+        - model: "gemini/gemma-4-31b-it"
+          model_name: "image"
+          rpm: 15
+
         - model: "gemini/gemma-4-31b-it"
           rpm: 15
 
@@ -90,16 +112,19 @@ router:
       api_key: "os.environ/OLLAMA_API_KEY"
       api_base: "os.environ/OLLAMA_BASE_URL"
       models:
+        - model: "ollama/kimi-k2.6:cloud"
+          model_name: "image"
+
         - model: "ollama/gemma4:31b-cloud"
 
 #    openrouter_basic:
 #      api_key: "os.environ/OPENROUTER_API_KEY"
 #      api_base: "os.environ/OPENROUTER_BASE_URL"
 #      models:
-#        - model: "openrouter/openai/gpt-oss-120b:free"  # Does not support structured output
+#        - model: "openrouter/openai/gpt-oss-120b:free"  # Lots of validation errors, json_schema support?
 
   settings:
-    num_retries: 2
+    num_retries: 1
     retry_after: 5
     cooldown_time: 30
     enable_pre_call_checks: true

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -314,7 +314,10 @@ def inline_schema_refs(schema: dict[str, Any]) -> dict[str, Any]:
             if "$ref" in node:
                 # $ref is always "#/$defs/ModelName"
                 ref_name = node["$ref"].split("/")[-1]
-                resolved = defs.get(ref_name, node)
+                resolved = defs.get(ref_name)
+                if resolved is None:
+                    # Return the node as-is if the reference cannot be resolved to avoid infinite recursion.
+                    return node
                 # Recursively resolve in case the target also has $refs
                 return _resolve(dict(resolved))
             return {k: _resolve(v) for k, v in node.items() if k != "$defs"}

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -300,13 +300,79 @@ def _heal_json(raw: str, schema: type[BaseModel]) -> str:
     return raw
 
 
+def inline_schema_refs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve all JSON Schema $ref pointers and remove $defs.
+
+    Pydantic generates $defs + $ref for nested models. Groq (and some other
+    providers) reject schemas containing $defs/$ref, so we inline every
+    reference before sending the schema to the provider.
+    """
+    defs = schema.get("$defs", {})
+
+    def _resolve(node: Any) -> Any:
+        if isinstance(node, dict):
+            if "$ref" in node:
+                # $ref is always "#/$defs/ModelName"
+                ref_name = node["$ref"].split("/")[-1]
+                resolved = defs.get(ref_name, node)
+                # Recursively resolve in case the target also has $refs
+                return _resolve(dict(resolved))
+            return {k: _resolve(v) for k, v in node.items() if k != "$defs"}
+        if isinstance(node, list):
+            return [_resolve(item) for item in node]
+        return node
+
+    return _resolve(schema)
+
+
+def enforce_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Patch every object node in an inlined schema for strict-mode compatibility.
+
+    Groq (and OpenAI strict mode) require:
+      - ``additionalProperties: false`` on every object
+      - Every key in ``properties`` must appear in ``required``
+
+    Pydantic's ``model_json_schema()`` omits both, so this pass adds them.
+    Fields with a ``default`` value are kept in ``required`` — strict mode
+    does not allow optional fields, but the model will still emit a value.
+    """
+    def _patch(node: Any) -> Any:
+        if isinstance(node, list):
+            return [_patch(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        # Recurse first so nested objects are patched before we inspect them
+        patched: dict[str, Any] = {k: _patch(v) for k, v in node.items()}
+
+        if patched.get("type") == "object" and "properties" in patched:
+            props = patched["properties"]
+            # All declared properties must be required in strict mode
+            existing_required: list[str] = list(patched.get("required") or [])
+            all_keys = list(props.keys())
+            merged_required = existing_required + [k for k in all_keys if k not in existing_required]
+            patched["required"] = merged_required
+            patched["additionalProperties"] = False
+
+        return patched
+
+    return _patch(schema)
+
+
 def build_json_schema_response_format(schema: type[BaseModel]) -> dict[str, Any]:
-    """Build a LiteLLM/OpenAI-style JSON Schema response format payload."""
+    """Build a LiteLLM/OpenAI-style JSON Schema response format payload.
+
+    Calls inline_schema_refs() to resolve $defs/$ref and enforce_strict_schema()
+    to add the ``additionalProperties: false`` / ``required`` constraints that
+    Groq strict mode demands, before sending to the provider.
+    """
+    inlined = inline_schema_refs(schema.model_json_schema())
+    strict_schema = enforce_strict_schema(inlined)
     return {
         "type": "json_schema",
         "json_schema": {
             "name": schema.__name__,
-            "schema": schema.model_json_schema(),
+            "schema": strict_schema,
             "strict": True,
         },
     }

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -205,6 +205,60 @@ class ResearchDatabase(DatabaseProvider):
                         self._conn.execute(
                             "ALTER TABLE slide_review_events ADD COLUMN description TEXT;"
                         )
+                    if "plan_generation" not in review_event_columns:
+                        self._conn.execute(
+                            "ALTER TABLE slide_review_events "
+                            "ADD COLUMN plan_generation INTEGER NOT NULL DEFAULT 0;"
+                        )
+
+                rc_columns = [
+                    info["name"]
+                    for info in self._conn.execute("PRAGMA table_info(retrieved_chunks)").fetchall()
+                ]
+                if rc_columns and "plan_generation" not in rc_columns:
+                    self._conn.execute("ALTER TABLE retrieved_chunks RENAME TO retrieved_chunks_old;")
+                    self._conn.execute(CREATE_RETRIEVED_CHUNKS_TABLE)
+                    self._conn.execute(
+                        """
+                        INSERT INTO retrieved_chunks (
+                            row_id, session_id, call_id, kind, artifact_id, document_id, text_content,
+                            score, rank, strategy, retrieved_at, agent_type, query, plan_generation
+                        )
+                        SELECT
+                            row_id, session_id, call_id, kind, artifact_id, document_id, text_content,
+                            score, rank, strategy, retrieved_at, agent_type, query, 0
+                        FROM retrieved_chunks_old;
+                        """
+                    )
+                    self._conn.execute("DROP TABLE retrieved_chunks_old;")
+                    for idx_sql in (
+                        "CREATE INDEX IF NOT EXISTS idx_retrieved_chunks_session_id "
+                        "ON retrieved_chunks(session_id);",
+                        "CREATE INDEX IF NOT EXISTS idx_retrieved_chunks_call_id "
+                        "ON retrieved_chunks(call_id);",
+                        "CREATE INDEX IF NOT EXISTS idx_retrieved_chunks_session_call "
+                        "ON retrieved_chunks(session_id, call_id);",
+                    ):
+                        self._conn.execute(idx_sql)
+
+                # Per-plan columns must exist before these indexes (migrations add columns on old DBs).
+                sre_columns = [
+                    info["name"]
+                    for info in self._conn.execute("PRAGMA table_info(slide_review_events)").fetchall()
+                ]
+                if sre_columns and "plan_generation" in sre_columns:
+                    self._conn.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_slide_review_events_session_plan "
+                        "ON slide_review_events(session_id, plan_generation);"
+                    )
+                rcc_columns = [
+                    info["name"] for info in self._conn.execute("PRAGMA table_info(retrieved_chunks)").fetchall()
+                ]
+                if rcc_columns and "plan_generation" in rcc_columns:
+                    self._conn.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_retrieved_chunks_session_plan "
+                        "ON retrieved_chunks(session_id, plan_generation);"
+                    )
             except Exception as e:
                 self._logger.log(f"[ResearchDatabase] Schema migration error: {e}")
         retrieval_ensure_artifact_search_index(self)
@@ -264,8 +318,13 @@ class ResearchDatabase(DatabaseProvider):
     def save_review_event(self, **kwargs) -> None:
         return slide.save_review_event(self, **kwargs)
 
-    def list_review_events(self, session_id: str) -> list[dict]:
-        return slide.list_review_events(self, session_id)
+    def list_review_events(
+        self, session_id: str, plan_generation: int | None = None
+    ) -> list[dict]:
+        return slide.list_review_events(self, session_id, plan_generation=plan_generation)
+
+    def delete_slides_not_in(self, slide_numbers: list[int]) -> None:
+        return slide.delete_slides_not_in(self, slide_numbers)
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -296,6 +355,7 @@ class ResearchDatabase(DatabaseProvider):
         query: str,
         strategy: str,
         agent_type: str,
+        plan_generation: int = 0,
     ) -> None:
         return retrieval_save_session_retrieval_batch(
             self,
@@ -305,6 +365,7 @@ class ResearchDatabase(DatabaseProvider):
             query,
             strategy,
             agent_type,
+            plan_generation=plan_generation,
         )
 
     def load_normalized_artifacts_for_keys(
@@ -317,8 +378,12 @@ class ResearchDatabase(DatabaseProvider):
     ) -> list[dict[str, Any]]:
         return retrieval_load_normalized_artifacts_for_call(self, session_id, call_id)
 
-    def load_normalized_artifacts_for_session(self, session_id: str) -> list[dict[str, Any]]:
-        return retrieval_load_normalized_artifacts_for_session(self, session_id)
+    def load_normalized_artifacts_for_session(
+        self, session_id: str, plan_generation: int | None = None
+    ) -> list[dict[str, Any]]:
+        return retrieval_load_normalized_artifacts_for_session(
+            self, session_id, plan_generation=plan_generation
+        )
 
     def load_retrieved_chunks(self, session_id: str | None = None) -> list[dict[str, Any]]:
         return retrieval_load_retrieved_chunks(self, session_id)

--- a/src/memory/research/database.py
+++ b/src/memory/research/database.py
@@ -192,10 +192,19 @@ class ResearchDatabase(DatabaseProvider):
                     info["name"]
                     for info in self._conn.execute("PRAGMA table_info(slide_review_events)").fetchall()
                 ]
-                if review_event_columns and "affected_slide_numbers" not in review_event_columns:
-                    self._conn.execute(
-                        "ALTER TABLE slide_review_events ADD COLUMN affected_slide_numbers TEXT;"
-                    )
+                if review_event_columns:
+                    if "affected_slide_numbers" not in review_event_columns:
+                        self._conn.execute(
+                            "ALTER TABLE slide_review_events ADD COLUMN affected_slide_numbers TEXT;"
+                        )
+                    if "location" not in review_event_columns:
+                        self._conn.execute(
+                            "ALTER TABLE slide_review_events ADD COLUMN location TEXT;"
+                        )
+                    if "description" not in review_event_columns:
+                        self._conn.execute(
+                            "ALTER TABLE slide_review_events ADD COLUMN description TEXT;"
+                        )
             except Exception as e:
                 self._logger.log(f"[ResearchDatabase] Schema migration error: {e}")
         retrieval_ensure_artifact_search_index(self)

--- a/src/memory/research/retrieval.py
+++ b/src/memory/research/retrieval.py
@@ -284,7 +284,7 @@ WITH keys AS (
         s.document_id AS document_id,
         s.score AS score
     FROM retrieved_chunks s
-    WHERE s.session_id = ?
+    WHERE s.session_id = ? AND s.plan_generation = ?
 )
 """
 
@@ -336,9 +336,29 @@ def load_normalized_artifacts_for_call(
 def load_normalized_artifacts_for_session(
     db: ResearchDatabase,
     session_id: str,
+    plan_generation: int | None = None,
 ) -> list[dict[str, Any]]:
-    sql = _LEDGER_KEYS_SESSION + _SESSION_OUTER_SELECT
-    rows = db.connection.execute(sql, (session_id,)).fetchall()
+    if plan_generation is None:
+        # Backward compatible: all ledger rows for the session (all plan generations).
+        sql = """
+        WITH keys AS (
+            SELECT
+                s.call_id AS call_id,
+                s.rank AS rank,
+                s.kind AS kind,
+                s.artifact_id AS artifact_id,
+                s.document_id AS document_id,
+                s.score AS score
+            FROM retrieved_chunks s
+            WHERE s.session_id = ?
+        )
+        """
+        params: tuple = (session_id,)
+    else:
+        sql = _LEDGER_KEYS_SESSION
+        params = (session_id, plan_generation)
+    sql = sql + _SESSION_OUTER_SELECT
+    rows = db.connection.execute(sql, params).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -350,14 +370,15 @@ def save_session_retrieval_batch(
     query: str,
     strategy: str,
     agent_type: str,
+    plan_generation: int = 0,
 ) -> None:
     if not items:
         return
     sql = """
         INSERT OR IGNORE INTO retrieved_chunks (
             session_id, call_id, kind, artifact_id, document_id, text_content,
-            score, rank, strategy, agent_type, query, retrieved_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            score, rank, strategy, agent_type, query, plan_generation, retrieved_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
     """
     with db.connection:
         for rank, item in enumerate(items):
@@ -375,6 +396,7 @@ def save_session_retrieval_batch(
                     strategy,
                     agent_type,
                     query,
+                    plan_generation,
                 ),
             )
     db._logger.log(

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -330,6 +330,8 @@ CREATE TABLE IF NOT EXISTS slide_review_events (
     assignment_id TEXT,
     issue_code TEXT,
     severity TEXT,
+    location TEXT,
+    description TEXT,
     fingerprint TEXT,
     rewrite_instruction_summary TEXT,
     affected_slide_numbers TEXT,

--- a/src/memory/research/schema.py
+++ b/src/memory/research/schema.py
@@ -324,6 +324,7 @@ CREATE TABLE IF NOT EXISTS slide_review_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL,
     cycle_number INTEGER NOT NULL,
+    plan_generation INTEGER NOT NULL DEFAULT 0,
     scope_type TEXT NOT NULL,
     scope_id TEXT NOT NULL,
     check_type TEXT NOT NULL,
@@ -356,7 +357,8 @@ CREATE TABLE IF NOT EXISTS retrieved_chunks (
     retrieved_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     agent_type TEXT,
     query TEXT,
-    UNIQUE(session_id, call_id, kind, artifact_id)
+    plan_generation INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(session_id, call_id, kind, artifact_id, plan_generation)
 );
 """
 

--- a/src/memory/research/slide.py
+++ b/src/memory/research/slide.py
@@ -89,6 +89,8 @@ def save_review_event(
     assignment_id: str | None = None,
     issue_code: str | None = None,
     severity: str | None = None,
+    location: str | None = None,
+    description: str | None = None,
     fingerprint: str | None = None,
     rewrite_instruction_summary: str | None = None,
     affected_slide_numbers: list[int] | None = None,
@@ -112,12 +114,14 @@ def save_review_event(
                 assignment_id,
                 issue_code,
                 severity,
+                location,
+                description,
                 fingerprint,
                 rewrite_instruction_summary,
                 affected_slide_numbers,
                 decision
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -128,6 +132,8 @@ def save_review_event(
                 assignment_id,
                 issue_code,
                 severity,
+                location,
+                description,
                 fingerprint,
                 rewrite_instruction_summary,
                 affected_json,
@@ -159,7 +165,7 @@ def list_review_events(db, session_id: str) -> list[dict]:
     rows = db._conn.execute(
         """
         SELECT session_id, cycle_number, scope_type, scope_id, check_type,
-               assignment_id, issue_code, severity, fingerprint,
+               assignment_id, issue_code, severity, location, description, fingerprint,
                rewrite_instruction_summary, affected_slide_numbers, decision, created_at
         FROM slide_review_events
         WHERE session_id = ?

--- a/src/memory/research/slide.py
+++ b/src/memory/research/slide.py
@@ -78,11 +78,24 @@ def clear_slide_review_events(db) -> None:
         db._conn.execute("DELETE FROM slide_review_events")
 
 
+def delete_slides_not_in(db, slide_numbers: list[int]) -> None:
+    """Deletes proto-slides whose slide_number is not in the given list."""
+    if not slide_numbers:
+        return
+    with db._conn:
+        placeholders = ",".join("?" * len(slide_numbers))
+        db._conn.execute(
+            f"DELETE FROM proto_slides WHERE slide_number NOT IN ({placeholders})",
+            slide_numbers,
+        )
+
+
 def save_review_event(
     db,
     *,
     session_id: str,
     cycle_number: int,
+    plan_generation: int = 0,
     scope_type: str,
     scope_id: str,
     check_type: str,
@@ -108,6 +121,7 @@ def save_review_event(
             INSERT INTO slide_review_events (
                 session_id,
                 cycle_number,
+                plan_generation,
                 scope_type,
                 scope_id,
                 check_type,
@@ -121,11 +135,12 @@ def save_review_event(
                 affected_slide_numbers,
                 decision
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
                 cycle_number,
+                plan_generation,
                 scope_type,
                 scope_id,
                 check_type,
@@ -161,18 +176,33 @@ def _row_affected_slide_numbers(row: sqlite3.Row) -> list[int] | None:
     return out or None
 
 
-def list_review_events(db, session_id: str) -> list[dict]:
-    rows = db._conn.execute(
-        """
-        SELECT session_id, cycle_number, scope_type, scope_id, check_type,
-               assignment_id, issue_code, severity, location, description, fingerprint,
-               rewrite_instruction_summary, affected_slide_numbers, decision, created_at
-        FROM slide_review_events
-        WHERE session_id = ?
-        ORDER BY cycle_number ASC, id ASC
-        """,
-        (session_id,),
-    ).fetchall()
+def list_review_events(
+    db, session_id: str, plan_generation: int | None = None
+) -> list[dict]:
+    if plan_generation is not None:
+        rows = db._conn.execute(
+            """
+            SELECT session_id, cycle_number, plan_generation, scope_type, scope_id, check_type,
+                   assignment_id, issue_code, severity, location, description, fingerprint,
+                   rewrite_instruction_summary, affected_slide_numbers, decision, created_at
+            FROM slide_review_events
+            WHERE session_id = ? AND plan_generation = ?
+            ORDER BY cycle_number ASC, id ASC
+            """,
+            (session_id, plan_generation),
+        ).fetchall()
+    else:
+        rows = db._conn.execute(
+            """
+            SELECT session_id, cycle_number, plan_generation, scope_type, scope_id, check_type,
+                   assignment_id, issue_code, severity, location, description, fingerprint,
+                   rewrite_instruction_summary, affected_slide_numbers, decision, created_at
+            FROM slide_review_events
+            WHERE session_id = ?
+            ORDER BY cycle_number ASC, id ASC
+            """,
+            (session_id,),
+        ).fetchall()
     result: list[dict] = []
     for row in rows:
         d = dict(row)

--- a/src/state.py
+++ b/src/state.py
@@ -205,6 +205,7 @@ class PresentationPlan(BaseModel):
 
 
 class ReviewAssignment(TypedDict):
+    plan_generation: int
     assignment_id: str
     cycle_number: int
     check_type: ReviewCheckType
@@ -221,10 +222,12 @@ class ActiveDispatch(TypedDict):
     dispatch_id: str
     kind: ReviewDispatchKind
     cycle_number: int
+    plan_generation: int
     expected_assignment_ids: List[str]
 
 
 class SlideWriteRecord(TypedDict):
+    plan_generation: int
     dispatch_id: str
     assignment_id: str
     group_idx: int
@@ -244,6 +247,7 @@ class CriticIssueRecord(TypedDict):
 
 
 class CriticResultRecord(TypedDict):
+    plan_generation: int
     dispatch_id: str
     assignment_id: str
     cycle_number: int
@@ -259,6 +263,7 @@ class CriticResultRecord(TypedDict):
 
 
 class ReviewCycleSummary(TypedDict):
+    plan_generation: int
     cycle_number: int
     issue_counts: dict[str, int]
     decision: str
@@ -269,6 +274,7 @@ class ReviewCycleSummary(TypedDict):
 class ReviewState(TypedDict):
     phase: ReviewPhase
     cycle_number: int
+    plan_generation: int
     max_cycles: int
     dispatch_counter: int
     active_dispatch: Optional[ActiveDispatch]
@@ -287,6 +293,7 @@ def make_initial_review_state(*, max_cycles: int = MAX_CYCLES) -> ReviewState:
     return {
         "phase": "initial_write",
         "cycle_number": 0,
+        "plan_generation": 0,
         "max_cycles": max_cycles,
         "dispatch_counter": 0,
         "active_dispatch": None,

--- a/src/tools/rag.py
+++ b/src/tools/rag.py
@@ -145,6 +145,7 @@ def retrieve_artifacts(
 
     session_id = context.get("session_id")
     agent_type = context.get("agent_type", "writer")
+    plan_generation = int(context.get("plan_generation", 0))
     if session_id:
         try:
             research_db.save_session_retrieval_batch(
@@ -154,6 +155,7 @@ def retrieve_artifacts(
                 query=query,
                 strategy=args.strategy,
                 agent_type=agent_type,
+                plan_generation=plan_generation,
             )
         except Exception as exc:
             research_db._logger.log(

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,0 +1,54 @@
+import os
+import yaml
+from dotenv import load_dotenv
+import litellm
+
+# Not definitive.  Most models support json_schema but aren't listed as such in litellm's static registry.
+
+def main():
+    # Load environment variables
+    load_dotenv()
+
+    config_path = os.path.join("src", "llm", "config.dev.yaml")
+    
+    # Read config
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    models = set()
+    
+    # Models in providers
+    providers = config.get("router", {}).get("providers", {})
+    for provider, data in providers.items():
+        for model_entry in data.get("models", []):
+            if "model" in model_entry:
+                models.add(model_entry["model"])
+
+    # Models in fallback_providers
+    fallback_providers = config.get("router", {}).get("fallback_providers", {})
+    for provider, data in fallback_providers.items():
+        for model_entry in data.get("models", []):
+            if "model" in model_entry:
+                models.add(model_entry["model"])
+
+    print(f"Checking response_format and json_schema support for {len(models)} unique models...")
+    print("-" * 80)
+    print(f"{'MODEL':<50} | {'response_format'} | {'json_schema'}")
+    print("-" * 80)
+    
+    for model in sorted(models):
+        try:
+            params = litellm.get_supported_openai_params(model=model)
+            supports_response_format = "response_format" in params if params else False
+            
+            supports_schema = litellm.supports_response_schema(model=model)
+            
+            rf_str = "YES" if supports_response_format else "NO "
+            js_str = "YES" if supports_schema else "NO "
+            
+            print(f"{model:<50} | {rf_str:<15} | {js_str}")
+        except Exception as e:
+            print(f"[ERR] {model:<44} | {str(e)}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,44 @@
+import os
+import yaml
+from dotenv import load_dotenv
+import litellm
+
+def main():
+    # Load environment variables
+    load_dotenv()
+
+    config_path = os.path.join("src", "llm", "config.dev.yaml")
+    
+    # Read config
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    models = set()
+    
+    # Models in providers
+    providers = config.get("router", {}).get("providers", {})
+    for provider, data in providers.items():
+        for model_entry in data.get("models", []):
+            if "model" in model_entry:
+                models.add(model_entry["model"])
+
+    # Models in fallback_providers
+    fallback_providers = config.get("router", {}).get("fallback_providers", {})
+    for provider, data in fallback_providers.items():
+        for model_entry in data.get("models", []):
+            if "model" in model_entry:
+                models.add(model_entry["model"])
+
+    print(f"Checking vision support for {len(models)} unique models...")
+    print("-" * 50)
+    
+    for model in sorted(models):
+        try:
+            # litellm.supports_vision() returns True/False
+            supports = litellm.supports_vision(model=model)
+            print(f"[{'YES' if supports else 'NO '}] {model}")
+        except Exception as e:
+            print(f"[ERR] {model} - {str(e)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added mistral and groq providors, though groq hits input token limit (8K/12K) too readily to be useful.  
Added test scripts for your used models against the registry for json schema and vision capability.  Not definitive, most of the models in config.sample.yaml support json schema in addition to json objects, but is not reflected in the registry.
Critics now pass affected slides, location, and description of issues to slide rewriters.  
Database's slide_review_events also contain these fields now.
Replan refactor (untested, only confirmed that main cycle completes successfully).