### PR TITLE
Feature/second narrative flow critic

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,7 @@ OPENAI_API_KEY=your_key_here
 GROQ_API_KEY=your_key_here
 MISTRAL_API_KEY=your_key_here
 LLAMA_CLOUD_API_KEY=your_key_here
+NVIDIA_NIM_API_KEY=your_key_here
 
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/main.py
+++ b/main.py
@@ -156,6 +156,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--force-accept-first-plan",
+        action="store_true",
+        default=False,
+        help=(
+            "If the critic/rewrite cycle cap is reached on the first presentation plan "
+            "and the supervisor would replan or reject, force acceptance and proceed to export."
+        ),
+    )
+    parser.add_argument(
         "--no-cache-control",
         action="store_true",
         default=False,
@@ -312,7 +321,8 @@ def _build_initial_state(
         "max_slides":        args.max_slides,
         "skip_supervisor":   args.skip_supervisor,
         "plan_number":       1,
-        "force_replan_at_max_cycles": args.force_replan,
+        "force_replan_at_max_cycles":        args.force_replan,
+        "force_accept_first_plan_at_cap":    args.force_accept_first_plan,
         "slide_numbers":     [],
         "presentation_plan": None,
         "review":            make_initial_review_state(max_cycles=args.max_cycles),

--- a/src/agents/prompts/critic_prompts.py
+++ b/src/agents/prompts/critic_prompts.py
@@ -46,7 +46,8 @@ Review Criteria:
 2. Clarity: Each slide’s role in the arc should be obvious; flag confusion, redundancy, or missing connective tissue between slides.
 3. Pacing: Flag abrupt jumps, repeated beats, or a weak opening/closing relative to the rest of the deck.
 
-You are not given source research text—judge only how slide content and plan intent work together. Do not flag missing citations or “unsupported” factual claims; that is out of scope for this pass.
+You are not given source research text—judge only how slide content and plan intent work together.  
+Ignore the key message of each slide when reviewing for narrative coherence.  Focus only on the titles, bullet points, and speaker notes.
 """
 
 

--- a/src/agents/prompts/critic_prompts.py
+++ b/src/agents/prompts/critic_prompts.py
@@ -58,7 +58,9 @@ def build_critic_output_format(output_model: type[BaseModel]) -> str:
             "Top-level keys MUST be exactly `summary`, `actionable`, and `issues` - do not wrap the payload in another key.",
             "If no meaningful issues exist, set actionable=false and issues=[].",
             "If one or more issues exist, set actionable=true and include every required field on each issue "
-            "(issue_code, severity, issue_type, location, rewrite_instruction).",
+            "(issue_code, severity, issue_type, location, affected_slide_numbers, rewrite_instruction).",
+            "On every issue, affected_slide_numbers must list every slide the issue applies to (non-empty for actionable issues); "
+            "for whole-deck concerns, list all target slide numbers.",
             "issue_code values must be unique within this response (e.g. ISS_001, ISS_002).",
             "Use the exact field names issue_code and issue_type - not `id`, `classification`, or other synonyms.",
             "location must pinpoint what to change (e.g. slide number and bullet or heading).",

--- a/src/agents/prompts/critic_prompts.py
+++ b/src/agents/prompts/critic_prompts.py
@@ -8,43 +8,45 @@ from pydantic import BaseModel
 
 from src.agents.prompts.common import schema_prompt_contract
 
-# Will have to be updated for multiple review criteria
 CRITIC_ROLE = """
-You are a Slide Deck Critic. Your job is to review assigned slides against the
-source research chunks and identify only meaningful issues that require correction.
-You must evaluate and report issues ONLY within the assigned review criteria for
-this pass; do not raise issues from criteria that were not assigned.
+You are a Slide Deck Critic. Your job is to review the assigned scope and surface only
+meaningful issues that require correction. You must evaluate and report issues ONLY within
+the assigned review criteria for this pass; do not raise issues from criteria that were not assigned.
 
 Core Directives:
 1. Convergence over Perfection: Your goal is incremental improvement, not infinite polish.
-An issue is only an "issue" if it triggers your assigned review criteria.
-2. Grounding over speculation: Do not require citations for claims that are clearly supported by the provided chunks, but flag hallucinations, unsupported claims, contradictions, and misleading framing.
-3. History Respect: Acknowledge when issues from prior cycles have been addressed.
-4. Sufficiency Check: If the assigned slides are adequately grounded and understandable, return no actionable issues.
-5. Scope Discipline: Review only the assigned scope. If the title slide is assigned for a grounding check, trivially pass it unless the instructions explicitly say otherwise.
-6. Criteria Discipline: If you notice a potential issue outside assigned criteria, ignore it for this run.
+2. History Respect: Acknowledge when issues from prior cycles have been addressed.
+3. Scope Discipline: Review only the assigned scope.
+4. Criteria Discipline: If you notice a potential issue outside your assigned criteria, ignore it for this run.
 
 For each issue found:
 - Assign a unique ID (ISS_001, ISS_002, ...)
-- Classify: factual_inaccuracy | hallucination | unsupported_claim | logical_gap | structural | clarity | contradiction
 - Severity: critical (Blocks publication) | major (Significantly degrades quality) | minor (Polish)
+- Location: pinpoint what to change (e.g. slide number and bullet or heading).
 - Provide a precise rewrite instruction that would fix the issue.
 """
 
-# Reserved for a future layout-focused critic pass; not wired in the current graph.
-LAYOUT_REVIEW_CRITERIA = """
-Layout and image-placement review criteria (modular block):
-Review the assigned slides against the IMAGE ASSETS listed in the prompt.
+GROUNDING_REVIEW_CRITERIA = """
+Review Criteria:
+2. Grounding over speculation: Do not require citations for claims that are clearly supported by the provided chunks, but flag hallucinations, unsupported claims, contradictions, and misleading framing.
+4. Sufficiency Check: If the assigned slides are adequately grounded and understandable, return no actionable issues.
 
-Image Placement Assessment:
-1. If `media_id` is set, verify the referenced image is relevant to the slide's content.
-2. If `media_id` is set, verify the layout choice matches the image's aspect ratio:
-   - landscape images -> media_top or media_bottom
-   - portrait images -> media_left or media_right
-   - square images -> media_left or media_right preferred
-3. If no image is used but a clearly relevant image asset exists for an evidence or
-   insight slide, raise a minor issue suggesting image inclusion with the specific Image ID.
-4. Do NOT penalize omission of images when no relevant image is available.
+For each issue found:
+- Classify: factual_inaccuracy | hallucination | unsupported_claim | logical_gap | structural | clarity | contradiction
+
+How to use evidence (the user message below includes baseline source chunks, in-session retrieval log, and image assets when applicable):
+- Review slide claims against the BASELINE SOURCE MATERIAL and IN-SESSION RETRIEVAL LOG together as the source of truth for grounding. Treat the combined evidence as what the writer was allowed to use.
+- If the combined evidence does not support a concrete claim on a slide, that is a grounding issue.
+- Identify only significant issues that require correction under these criteria.
+"""
+
+NARRATIVE_REVIEW_CRITERIA = """
+Review Criteria:
+1. Narrative coherence: The deck should read as one story—logical order, clear transitions, and a thesis that the slides support end-to-end.
+2. Clarity: Each slide’s role in the arc should be obvious; flag confusion, redundancy, or missing connective tissue between slides.
+3. Pacing: Flag abrupt jumps, repeated beats, or a weak opening/closing relative to the rest of the deck.
+
+You are not given source research text—judge only how slide content and plan intent work together. Do not flag missing citations or “unsupported” factual claims; that is out of scope for this pass.
 """
 
 
@@ -61,6 +63,7 @@ def build_critic_output_format(output_model: type[BaseModel]) -> str:
             "Use the exact field names issue_code and issue_type - not `id`, `classification`, or other synonyms.",
             "location must pinpoint what to change (e.g. slide number and bullet or heading).",
             "rewrite_instruction must be one concrete edit directive per issue, not only a restatement of the problem.",
+            "If no changes are needed, set actionable=false and issues=[].",
         ],
     )
 
@@ -87,7 +90,7 @@ def format_retrieved_artifact_row(row: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def build_critic_user_prompt(
+def build_grounding_critic_user_prompt(
     *,
     cycle_number: int,
     check_type: str,
@@ -101,7 +104,7 @@ def build_critic_user_prompt(
     image_block: str,
     output_model: type[BaseModel],
 ) -> str:
-    """Assemble the full user message for a critic run (ingested by `SlideCriticAgent._call`)."""
+    """Assemble the user message for a grounding / evidence-aware critic run."""
     return "\n".join(
         [
             f"Cycle: {cycle_number}",
@@ -123,13 +126,35 @@ def build_critic_user_prompt(
             "",
             "AVAILABLE IMAGE ASSETS:",
             image_block or "(none)",
+            build_critic_output_format(output_model),
+        ]
+    )
+
+
+def build_narrative_critic_user_prompt(
+    *,
+    cycle_number: int,
+    check_type: str,
+    scope_type: str,
+    scope_id: str,
+    target_slide_numbers: list[int],
+    blueprint_block: str,
+    slides_block: str,
+    output_model: type[BaseModel],
+) -> str:
+    """Assemble the user message for a narrative / deck-flow critic (no source chunks or RAG)."""
+    return "\n".join(
+        [
+            f"Cycle: {cycle_number}",
+            f"Check type: {check_type}",
+            f"Scope: {scope_type}::{scope_id}",
+            f"Target slides: {target_slide_numbers}",
             "",
-            "Identify only significant issues that break grounding, clarity, coherence, or the review criteria. "
-            "If no changes are needed, set actionable=false and issues=[].",
-            "Review the slides against the BASELINE SOURCE MATERIAL and IN-SESSION RETRIEVAL LOG. Treat this combined evidence as the source of truth for grounding checks.",
-            "If the combined evidence is missing support for a concrete claim on a slide, treat that as a grounding issue.",
-            "Review the slides against the BASELINE SOURCE MATERIAL and IN-SESSION RETRIEVAL LOG. Treat this combined evidence as the source of truth for grounding checks.",
+            "SLIDE ASSIGNMENTS (plan intent for slides in scope):",
+            blueprint_block or "(none)",
             "",
+            "CURRENT SLIDES (draft content, presentation order):",
+            slides_block,
             build_critic_output_format(output_model),
         ]
     )

--- a/src/agents/prompts/writer_prompts.py
+++ b/src/agents/prompts/writer_prompts.py
@@ -48,12 +48,15 @@ dense research data into high-impact, professional presentation slides.
      * `portrait` (taller than wide) -> use `media_left` or `media_right`
      * `square` -> prefer `media_left` or `media_right`
    - Reduce bullet density slightly to leave room for the image (3 tight bullets beats 5 verbose ones).
-   - Lean on the VLM description in each IMAGE ASSETS line as your primary guide to what the image shows; \
+   - Lean on the contextualized text in each IMAGE ASSETS line as your primary guide to what the image shows; \
      the paper caption portion is a secondary signal.
 
    Use each image at most once across this batch of slides. The default disposition is to \
    use an image when one is relevant; only omit it if it genuinely does not support any slide \
    in this batch.
+
+Note: If the two_column layout is chosen, there should be only two bullets, with all relevant information \
+    in the sub-bullets of their respective bullet.
 """
 
 SLIDE_REWRITER_ROLE = """

--- a/src/agents/prompts/writer_prompts.py
+++ b/src/agents/prompts/writer_prompts.py
@@ -81,14 +81,21 @@ Only deviate from the reviewer instructions if it counters your imperative to gr
 """
 
 
-def build_assignment_block(slide_blueprints: list[dict]) -> str:
-    """Format slide blueprint list for SLIDE ASSIGNMENTS blocks (retrieval and generation turns)."""
-    return "\n".join(
-        f"Slide {bp.get('slide_number', i + 1)}: "
-        f"[{bp.get('narrative_role', 'evidence')}] "
-        f'"{bp.get("working_title", "")}" - {bp.get("intent", "")}'
-        for i, bp in enumerate(slide_blueprints)
-    )
+def build_assignment_block(slide_blueprints: list[dict], *, include_working_title: bool = True) -> str:
+    """Format slide blueprint list for SLIDE ASSIGNMENTS blocks (retrieval and generation turns).
+
+    ``include_working_title`` should be False for rewrite passes: the current title is already
+    present in the existing slide drafts, so repeating the planner's original working title creates
+    a competing anchor that can suppress critic-requested title changes.
+    """
+    lines = []
+    for i, bp in enumerate(slide_blueprints):
+        line = f"Slide {bp.get('slide_number', i + 1)}: [{bp.get('narrative_role', 'evidence')}]"
+        if include_working_title:
+            line += f' "{bp.get("working_title", "")}"'
+        line += f" - {bp.get('intent', '')}"
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def build_slide_base_prompt_parts(
@@ -137,7 +144,8 @@ def build_slide_retrieval_turns(
     existing_slides: list[ProtoSlide],
 ) -> list[dict]:
     """First user turn for tool-enabled runs: require retrieve_artifacts, then evidence brief."""
-    assignment_block = build_assignment_block(slide_blueprints)
+    is_rewrite = bool(rewrite_instructions.strip())
+    assignment_block = build_assignment_block(slide_blueprints, include_working_title=not is_rewrite)
     existing_slides_block = "\n\n".join(
         format_slide_for_prompt(slide) for slide in existing_slides
     )
@@ -200,7 +208,7 @@ def build_slide_rewrite_user_prompt(
     existing_slides: list[ProtoSlide],
 ) -> str:
     """User message for critic-driven slide revision."""
-    blueprint_block = build_assignment_block(slide_blueprints)
+    blueprint_block = build_assignment_block(slide_blueprints, include_working_title=False)
     existing_slides_block = "\n\n".join(
         format_slide_for_prompt(slide) for slide in existing_slides
     )

--- a/src/agents/slide_critic.py
+++ b/src/agents/slide_critic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any, Literal, TypedDict
+from typing import Literal, TypedDict, cast
 
 from langgraph.types import Command
 from pydantic import BaseModel, Field
@@ -10,24 +10,24 @@ from src.agents.base import BaseLLMAgent
 from src.agents.prompts.common import format_image_assets_block, format_slide_for_prompt, ordered_chunk_texts
 from src.agents.prompts.critic_prompts import (
     CRITIC_ROLE,
-    build_critic_user_prompt,
+    GROUNDING_REVIEW_CRITERIA,
+    NARRATIVE_REVIEW_CRITERIA,
+    build_grounding_critic_user_prompt,
+    build_narrative_critic_user_prompt,
     format_retrieved_artifact_row,
     format_rewrite_instruction,
 )
 from src.memory.research.database import ResearchDatabase
 from src.memory.research.schema import ProtoSlide
-from src.state import (
-    CriticResultRecord,
-    ResearchState,
-    ReviewAssignment,
-)
+from src.state import CriticResultRecord, ResearchState, ReviewCheckType
 
 
 class CriticDispatch(TypedDict):
     """State payload delivered to a critic node via LangGraph's Send() API.
 
-    Carries everything the critic needs: which slides to review, the source
-    chunks those slides were written from, the plan blueprint for intent context.
+    Carries scope, plan metadata, chunk IDs and blueprints (for grounding), and
+    the slides to review. Narrative reviews may fill slide lists from blueprints
+    when ``target_slide_numbers`` is empty.
     """
 
     plan_number: int
@@ -35,7 +35,7 @@ class CriticDispatch(TypedDict):
     assignment_id: str
     cycle_number: int
     session_id: str
-    check_type: str
+    check_type: ReviewCheckType
     scope_type: str
     scope_id: str
     group_idx: int
@@ -50,7 +50,7 @@ class CriticIssue(BaseModel):
     issue_code: str = Field(description="Unique issue id like ISS_001")
     severity: Literal["critical", "major", "minor"]
     issue_type: str
-    location: str
+    location: str = Field(description="Pinpoint what to change (e.g. slide number and bullet or heading).")
     affected_slide_numbers: list[int] = Field(default_factory=list)
     rewrite_instruction: str = Field(description="Precise instruction describing how to fix the issue.")
 
@@ -71,94 +71,55 @@ class CriticOutput(BaseModel):
 
 
 class SlideCriticAgent(BaseLLMAgent):
-    """LLM-backed agent that reviews a batch of slides for grounding and consistency issues.
-
-    Each instance is dispatched for a single critic assignment (one slide group per cycle).
-    It loads the current slide drafts, the baseline source chunks, and the session-wide
-    retrieval log, then asks the LLM to produce a structured list of issues.  Results are
+    """Base critic: shared LLM call, issue fingerprinting, DB persistence, and result shaping.
+    Each instance is dispatched for a single critic assignment. Results are
     fingerprinted and persisted to the research database so the supervisor can detect
     recurring problems across cycles and avoid infinite rewrite loops on stable findings.
+
+    Subclasses supply ``review_criteria`` and implement ``_build_user_prompt`` (and
+    optionally ``_resolved_target_slide_numbers`` for what was actually in scope).
     """
 
-    def __init__(self, *, log_display: str | None = None) -> None:
-        """Initialise with the critic system prompt; ``log_display`` labels parallel critic logs."""
-        super().__init__("critic", system_prompt=CRITIC_ROLE, log_display=log_display)
+    def __init__(self, *, log_display: str | None = None, review_criteria: str) -> None:
+        """Initialise with the critic role and review criteria system prompt.
+         ``log_display`` labels parallel critic logs."""
+        super().__init__("critic", system_prompt=CRITIC_ROLE + review_criteria, log_display=log_display)
 
-    def _load_session_retrieval_log(
-        self, session_id: str, plan_number: int | None = None
-    ) -> str:
-        """Load and format all normalized research artifacts retrieved during the session.
+    def _resolved_target_slide_numbers(self, state: CriticDispatch) -> list[int]:
+        """Slide numbers in review scope; default is explicit ``target_slide_numbers`` only."""
+        return list(state.get("target_slide_numbers") or [])
 
-        Returns a newline-separated block of artifact rows suitable for injection into
-        the review prompt, or an empty string when no session ID is provided.
-        """
-        if not session_id:
-            return ""
-        with ResearchDatabase() as research_db:
-            rows = research_db.load_normalized_artifacts_for_session(
-                session_id, plan_number=plan_number
-            )
-        ordered: list[str] = []
-        for row in rows:
-            ordered.append(format_retrieved_artifact_row(row))
-        return "\n\n".join(ordered)
-
-    def _build_user_prompt(self, state: CriticDispatch) -> str:
-        """Assemble the full review packet for the LLM.
-
-        Combines the plan intent (blueprint block), current slide drafts, baseline source
-        chunks, the session-wide retrieval log, and any embedded image assets into a single
-        structured prompt consumed by the critic LLM.
-        """
-        slide_numbers = state.get("target_slide_numbers", [])
-        # Fetch the current persisted draft for each requested slide number from the research database.
+    def _load_slides(self, slide_numbers: list[int]) -> list[ProtoSlide]:
+        """Shared helper to load slides from the database."""
         slides: list[ProtoSlide] = []
         with ResearchDatabase() as research_db:
             for slide_number in slide_numbers:
                 slide = research_db.load_slide(slide_number)
                 if slide is not None:
                     slides.append(slide)
-        
-        pnum = int(state.get("plan_number", 1))
-        retrieval_log = self._load_session_retrieval_log(
-            state.get("session_id", ""), plan_number=pnum
-        )
-        blueprints = state.get("slide_blueprints", [])
-        blueprint_block = "\n".join(
-            f"Slide {bp.get('slide_number')}: {bp.get('working_title', '')} — {bp.get('intent', '')}"
-            for bp in blueprints
-            if bp.get("slide_number") in set(slide_numbers)
-        )
-        slides_block = "\n\n".join(format_slide_for_prompt(slide) for slide in slides) or "No slides found."
-        chunk_ids = state.get("chunk_ids", [])
-        baseline_chunks_block = ""
-        with ResearchDatabase() as research_db:
-            image_metadatas = research_db.get_images_for_chunks(chunk_ids)
-            if chunk_ids:
-                placeholders = ",".join(["?"] * len(chunk_ids))
-                rows = research_db.connection.execute(
-                    f"SELECT id, text, contextualized_text FROM text_chunks "
-                    f"WHERE id IN ({placeholders})",
-                    chunk_ids,
-                ).fetchall()
-                # Return chunk text blocks in the caller-provided chunk order (see ordered_chunk_texts in common).
-                ordered_texts = ordered_chunk_texts(rows, chunk_ids)
-                baseline_chunks_block = "\n\n".join(ordered_texts)
+        return slides
 
-        image_block = format_image_assets_block(image_metadatas)
-        return build_critic_user_prompt(
-            cycle_number=state["cycle_number"],
-            check_type=state["check_type"],
-            scope_type=state["scope_type"],
-            scope_id=state["scope_id"],
-            target_slide_numbers=slide_numbers,
-            blueprint_block=blueprint_block,
-            slides_block=slides_block,
-            baseline_chunks_block=baseline_chunks_block,
-            retrieval_log=retrieval_log,
-            image_block=image_block,
-            output_model=CriticOutput,
+    def _format_blueprint_block(
+        self,
+        blueprints: list[dict],
+        target_slide_numbers: list[int],
+        *,
+        all_blueprints_if_no_target: bool = False,
+    ) -> str:
+        """Shared helper to format the SLIDE ASSIGNMENTS text block."""
+        if not target_slide_numbers:
+            bps = list(blueprints) if all_blueprints_if_no_target else []
+        else:
+            want = set(target_slide_numbers)
+            bps = [bp for bp in blueprints if bp.get("slide_number") in want]
+        return "\n".join(
+            f"Slide {bp.get('slide_number')}: {bp.get('working_title', '')} — {bp.get('intent', '')}"
+            for bp in bps
         )
+
+    def _build_user_prompt(self, state: CriticDispatch) -> str:
+        """Subclasses assemble the user message (grounding vs narrative, etc.)."""
+        raise NotImplementedError
 
     def run(self, state: CriticDispatch) -> Command:
         """Execute the critic review for one assignment and return a LangGraph Command.
@@ -166,17 +127,20 @@ class SlideCriticAgent(BaseLLMAgent):
         Calls the LLM with the assembled review prompt, converts each issue to a
         fingerprinted dict, and persists every issue (or a pass event when none are found)
         to the research database.  Returns a Command carrying a CriticResultRecord for the
-        supervisor to evaluate on its next invocation.
+        Supervisor to evaluate on its next invocation.
         """
         self._set_session_id(state)
         self._set_plan_number(state)
         plan_num = int(state.get("plan_number", 1))
+        check_type = state["check_type"]
+        reviewed_slide_numbers = self._resolved_target_slide_numbers(state)
         prompt = self._build_user_prompt(state)
         result: CriticOutput = self._call(
             [{"role": "user", "content": prompt}],
             schema=CriticOutput,
             model="critic",
         )
+
         issues: list[dict] = []
         # Return a short, stable hash that uniquely identifies an issue by its structural attributes.
         # The fingerprint is scoped to (scope_type, scope_id, issue_type, location) so the
@@ -195,7 +159,7 @@ class SlideCriticAgent(BaseLLMAgent):
                     "rewrite_instruction": issue.rewrite_instruction,
                 }
             )
-            
+
         rewrite_instructions = "\n".join(
             format_rewrite_instruction(issue) for issue in issues if issue["rewrite_instruction"].strip()
         )
@@ -203,18 +167,18 @@ class SlideCriticAgent(BaseLLMAgent):
             "dispatch_id": state["dispatch_id"],
             "assignment_id": state["assignment_id"],
             "cycle_number": state["cycle_number"],
-            "check_type": "grounding_consistency",
+            "check_type": check_type,
             "scope_type": state["scope_type"],
             "scope_id": state["scope_id"],
             "group_idx": state["group_idx"],
-            "target_slide_numbers": state.get("target_slide_numbers", []),
+            "target_slide_numbers": reviewed_slide_numbers,
             "actionable": bool(result.actionable and issues),
             "rewrite_instructions": rewrite_instructions,
             "summary": result.summary,
             "issues": issues,
         }
         msg = (
-            f"[critic] assignment={state['assignment_id']} "
+            f"[critic] check_type={check_type} assignment={state['assignment_id']} "
             f"actionable={critic_result['actionable']} issues={len(issues)}"
         )
         with ResearchDatabase() as research_db:
@@ -225,7 +189,7 @@ class SlideCriticAgent(BaseLLMAgent):
                     plan_number=plan_num,
                     scope_type=state["scope_type"],
                     scope_id=state["scope_id"],
-                    check_type=state["check_type"],
+                    check_type=check_type,
                     assignment_id=state["assignment_id"],
                     issue_code=issue["issue_code"],
                     severity=issue["severity"],
@@ -241,21 +205,129 @@ class SlideCriticAgent(BaseLLMAgent):
                     plan_number=plan_num,
                     scope_type=state["scope_type"],
                     scope_id=state["scope_id"],
-                    check_type=state["check_type"],
+                    check_type=check_type,
                     assignment_id=state["assignment_id"],
                     decision="pass",
                 )
-                
+
         return Command(update={"critic_results": [critic_result], "messages": [msg]})
+
+
+class GroundingCriticAgent(SlideCriticAgent):
+    """Grounding / consistency: baseline chunks, in-session retrieval log, and image assets."""
+
+    def __init__(self, *, log_display: str | None = None) -> None:
+        super().__init__(log_display=log_display, review_criteria=GROUNDING_REVIEW_CRITERIA)
+
+    def _load_session_retrieval_log(
+        self, session_id: str, plan_number: int | None = None
+    ) -> str:
+        if not session_id:
+            return ""
+        with ResearchDatabase() as research_db:
+            rows = research_db.load_normalized_artifacts_for_session(
+                session_id, plan_number=plan_number
+            )
+        return "\n\n".join(format_retrieved_artifact_row(row) for row in rows)
+
+    def _build_user_prompt(self, state: CriticDispatch) -> str:
+        slide_numbers = self._resolved_target_slide_numbers(state)
+        slides = self._load_slides(slide_numbers)
+        pnum = int(state.get("plan_number", 1))
+        retrieval_log = self._load_session_retrieval_log(state.get("session_id", ""), plan_number=pnum)
+        blueprints = state.get("slide_blueprints", [])
+        blueprint_block = self._format_blueprint_block(
+            blueprints, slide_numbers, all_blueprints_if_no_target=False
+        )
+        slides_block = "\n\n".join(format_slide_for_prompt(slide) for slide in slides) or "No slides found."
+        chunk_ids = state.get("chunk_ids", [])
+        baseline_chunks_block = ""
+        with ResearchDatabase() as research_db:
+            image_metadatas = research_db.get_images_for_chunks(chunk_ids)
+            if chunk_ids:
+                placeholders = ",".join(["?"] * len(chunk_ids))
+                rows = research_db.connection.execute(
+                    f"SELECT id, text, contextualized_text FROM text_chunks "
+                    f"WHERE id IN ({placeholders})",
+                    chunk_ids,
+                ).fetchall()
+                ordered_texts = ordered_chunk_texts(rows, chunk_ids)
+                baseline_chunks_block = "\n\n".join(ordered_texts)
+        image_block = format_image_assets_block(image_metadatas)
+        return build_grounding_critic_user_prompt(
+            cycle_number=state["cycle_number"],
+            check_type=state["check_type"],
+            scope_type=state["scope_type"],
+            scope_id=state["scope_id"],
+            target_slide_numbers=slide_numbers,
+            blueprint_block=blueprint_block,
+            slides_block=slides_block,
+            baseline_chunks_block=baseline_chunks_block,
+            retrieval_log=retrieval_log,
+            image_block=image_block,
+            output_model=CriticOutput,
+        )
+
+
+class NarrativeCriticAgent(SlideCriticAgent):
+    """Narrative coherence: proto-slides and plan intent only (no source chunks, RAG log, or image metadata)."""
+
+    def __init__(self, *, log_display: str | None = None) -> None:
+        super().__init__(log_display=log_display, review_criteria=NARRATIVE_REVIEW_CRITERIA)
+
+    def _resolved_target_slide_numbers(self, state: CriticDispatch) -> list[int]:
+        raw = list(state.get("target_slide_numbers") or [])
+        if raw:
+            return raw
+        return [
+            int(n)
+            for n in (bp.get("slide_number") for bp in (state.get("slide_blueprints") or []))
+            if n is not None
+        ]
+
+    def _build_user_prompt(self, state: CriticDispatch) -> str:
+        slide_numbers = self._resolved_target_slide_numbers(state)
+        slides = self._load_slides(slide_numbers)
+        blueprints = state.get("slide_blueprints", [])
+        blueprint_block = self._format_blueprint_block(
+            blueprints, slide_numbers, all_blueprints_if_no_target=not slide_numbers
+        )
+        slides_block = "\n\n".join(format_slide_for_prompt(slide) for slide in slides) or "No slides found."
+        return build_narrative_critic_user_prompt(
+            cycle_number=state["cycle_number"],
+            check_type=state["check_type"],
+            scope_type=state["scope_type"],
+            scope_id=state["scope_id"],
+            target_slide_numbers=slide_numbers,
+            blueprint_block=blueprint_block,
+            slides_block=slides_block,
+            output_model=CriticOutput,
+        )
+
+
+_CRITIC_AGENT_MAP: dict[ReviewCheckType, type[SlideCriticAgent]] = {
+    "grounding_consistency": GroundingCriticAgent,
+    "narrative_coherence": NarrativeCriticAgent,
+}
+
+
+def _critic_class_for(check_type: str) -> type[SlideCriticAgent]:
+    if check_type not in _CRITIC_AGENT_MAP:
+        expected = tuple(_CRITIC_AGENT_MAP)
+        raise KeyError(
+            f"Unknown critic check_type {check_type!r}; expected one of {expected}"
+        )
+    return _CRITIC_AGENT_MAP[cast(ReviewCheckType, check_type)]
 
 
 def critic_node(state: CriticDispatch | ResearchState) -> Command:
     """LangGraph node entry point for a critic assignment.
-
     Constructs a labelled SlideCriticAgent and delegates to its run() method.
     The type annotation is wider than the runtime type because LangGraph routes
     through ResearchState; the narrower CriticDispatch is always received at runtime.
     """
+
+    check_type = str(state.get("check_type") or "grounding_consistency")
 
     # Modify log prefixes so parallel critics are easy to tell apart in logs.
     # Fall back to blueprint slide numbers when the supervisor did not narrow the assignment.
@@ -266,12 +338,12 @@ def critic_node(state: CriticDispatch | ResearchState) -> Command:
             if n is not None:
                 nums.append(n)
     if not nums:
-        log_display = "Critic[empty]"
+        log_display = f"Critic[empty, {check_type}]"
     else:
         ordered = sorted(int(n) for n in nums)
         lo, hi = ordered[0], ordered[-1]
         span = f"slides {lo}-{hi}" if lo != hi else f"slide {lo}"
-        log_display = f"Critic[{span}, group {state.get('group_idx', '?')}]"
+        log_display = f"Critic[{check_type}, {span}, group {state.get('group_idx', '?')}]"
 
-    # type: ignore[arg-type] is intentional — see docstring above.
-    return SlideCriticAgent(log_display=log_display).run(state)  # type: ignore[arg-type]
+    agent_cls = _critic_class_for(check_type)
+    return agent_cls(log_display=log_display).run(state)  # type: ignore[arg-type]

--- a/src/agents/slide_critic.py
+++ b/src/agents/slide_critic.py
@@ -4,7 +4,7 @@ import hashlib
 from typing import Literal, TypedDict, cast
 
 from langgraph.types import Command
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.agents.base import BaseLLMAgent
 from src.agents.prompts.common import format_image_assets_block, format_slide_for_prompt, ordered_chunk_texts
@@ -51,7 +51,13 @@ class CriticIssue(BaseModel):
     severity: Literal["critical", "major", "minor"]
     issue_type: str
     location: str = Field(description="Pinpoint what to change (e.g. slide number and bullet or heading).")
-    affected_slide_numbers: list[int] = Field(default_factory=list)
+    affected_slide_numbers: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Every slide this issue touches; required for actionable issues. "
+            "Deck-wide issues must list all target slide numbers."
+        ),
+    )
     rewrite_instruction: str = Field(description="Precise instruction describing how to fix the issue.")
 
 
@@ -68,6 +74,23 @@ class CriticOutput(BaseModel):
         default_factory=list,
         description="List of specific issues found. Leave empty if actionable is False."
     )
+
+    # Need to use model_validator here instead of schema enforcement because schema enforcement
+    # does not enforce semantic relationships between fields.
+    @model_validator(mode="after")
+    def _require_affected_slides_when_actionable(self) -> CriticOutput:
+        if not self.actionable:
+            return self
+        if not self.issues:
+            raise ValueError("When actionable=True, issues must contain at least one issue.")
+        for idx, issue in enumerate(self.issues):
+            if not issue.affected_slide_numbers:
+                code = issue.issue_code or f"index {idx}"
+                raise ValueError(
+                    f"When actionable=True, every issue must have non-empty affected_slide_numbers; "
+                    f"issue {code!r} has an empty list."
+                )
+        return self
 
 
 class SlideCriticAgent(BaseLLMAgent):

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -363,7 +363,8 @@ class SupervisorAgent(BaseLLMAgent):
                 plan_number=int(state.get("plan_number", 1)),
                 scope_type="deck",
                 scope_id="deck",
-                check_type="grounding_consistency",
+                # Supervisor-level routing decision event (not a critic check).
+                check_type="supervisor",
                 decision="replan",
             )
 
@@ -407,7 +408,8 @@ class SupervisorAgent(BaseLLMAgent):
                 plan_number=plan_number,
                 scope_type="deck",
                 scope_id="deck",
-                check_type="grounding_consistency",
+                # Supervisor-level routing decision event (not a critic check).
+                check_type="supervisor",
                 decision="accept",
             )
         return Command(
@@ -545,7 +547,8 @@ class SupervisorAgent(BaseLLMAgent):
                     plan_number=plan_number,
                     scope_type="deck",
                     scope_id="deck",
-                    check_type="grounding_consistency",
+                    # Supervisor-level routing decision event (not a critic check).
+                    check_type="supervisor",
                     decision="accept",
                 )
             return Command(

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -8,6 +8,8 @@ always override an LLM "accept".  Hitting the critic/rewrite cycle cap while rep
 remains triggers a full replan; once ``plan_number`` exceeds ``MAX_REPLANS`` the run must
 terminate: it exports unless aggregated critic severity counts still show critical issues.
 """
+from __future__ import annotations
+
 import json
 
 from langgraph.graph import END
@@ -17,8 +19,16 @@ from pydantic import BaseModel
 from src.memory.research.database import ResearchDatabase
 from src.memory.research.replan_backup import backup_replan_debug_snapshot
 from src.agents.base import BaseLLMAgent
+from src.agents.prompts.critic_prompts import format_rewrite_instruction
 from src.agents.prompts.supervisor_prompts import SUPERVISOR_ROLE, build_supervisor_user_prompt
-from src.state import MAX_CYCLES, MAX_REPLANS, ResearchState, ReviewAssignment, make_initial_review_state
+from src.state import (
+    MAX_CYCLES,
+    MAX_REPLANS,
+    PresentationPlan,
+    ResearchState,
+    ReviewAssignment,
+    make_initial_review_state,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -35,16 +45,6 @@ class SupervisorOutput(BaseModel):
     decision:  str   # "accept" | "revise" | "replan"
     reasoning: str
     feedback:  str = ""
-
-def _severity_counts(results: list[dict]) -> dict[str, int]:
-    """Aggregate issue counts by severity across all critic results for a single cycle."""
-    counts = {"critical": 0, "major": 0, "minor": 0}
-    for result in results:
-        for issue in result.get("issues", []):
-            severity = issue.get("severity")
-            if severity in counts:
-                counts[severity] += 1
-    return counts
 
 
 def _all_actionable_issues_are_persistent_minor(
@@ -71,8 +71,8 @@ def _all_actionable_issues_are_persistent_minor(
     return saw_issue
 
 
-def _build_group_assignments(*, plan, cycle_number: int) -> list[ReviewAssignment]:
-    """Build one critic ReviewAssignment per slide group in the presentation plan.
+def _build_grounding_assignments(*, plan: PresentationPlan, cycle_number: int) -> list[ReviewAssignment]:
+    """Build one grounding critic ReviewAssignment per slide group in the presentation plan.
 
     Critics are scoped to groups so each assignment shares the same source chunks and
     narrative context, keeping review prompts focused and findings comparable across cycles.
@@ -88,13 +88,40 @@ def _build_group_assignments(*, plan, cycle_number: int) -> list[ReviewAssignmen
                 "scope_type": "group",
                 "scope_id": str(idx),
                 "group_idx": idx,
-                "chunk_ids": list(dict.fromkeys(cid for bp in group.slide_blueprints for cid in bp.source_chunk_ids)),
+                "chunk_ids": list(
+                    dict.fromkeys(cid for bp in group.slide_blueprints for cid in bp.source_chunk_ids)
+                ),
                 "slide_blueprints": [bp.model_dump() for bp in group.slide_blueprints],
                 "target_slide_numbers": target_slide_numbers,
                 "rewrite_instructions": "",
             }
         )
     return assignments
+
+
+def _build_narrative_assignment(*, plan: PresentationPlan, cycle_number: int) -> ReviewAssignment:
+    """Build the deck-scoped narrative critic assignment (one per critic cycle, ``group_idx=-1``)."""
+    all_blueprints = [bp.model_dump() for g in plan.slide_groups for bp in g.slide_blueprints]
+    target_slide_numbers = [bp["slide_number"] for bp in all_blueprints]
+    return {
+        "assignment_id": f"critic-c{cycle_number}-narrative",
+        "cycle_number": cycle_number,
+        "check_type": "narrative_coherence",
+        "scope_type": "deck",
+        "scope_id": "deck",
+        "group_idx": -1,
+        "chunk_ids": [],
+        "slide_blueprints": all_blueprints,
+        "target_slide_numbers": target_slide_numbers,
+        "rewrite_instructions": "",
+    }
+
+
+def _build_critic_assignments(*, plan: PresentationPlan, cycle_number: int) -> list[ReviewAssignment]:
+    """All critic work for one cycle: per-group grounding plus one deck-level narrative pass."""
+    return _build_grounding_assignments(plan=plan, cycle_number=cycle_number) + [
+        _build_narrative_assignment(plan=plan, cycle_number=cycle_number)
+    ]
 
 
 def _format_dispatch_targets(assignments: list[ReviewAssignment]) -> str:
@@ -114,56 +141,148 @@ def _format_dispatch_targets(assignments: list[ReviewAssignment]) -> str:
     return "; ".join(parts)
 
 
-def _build_rewrite_assignments(
-    *, plan, results: list[dict], cycle_number: int
-) -> list[ReviewAssignment]:
-    """Build targeted rewrite ReviewAssignments from actionable critic results.
+def _clip_issue_to_group_slides(issue: dict, group_slides: set[int]) -> dict | None:
+    """Shallow copy of *issue* with ``affected_slide_numbers`` limited to the overlap with *group_slides*.
 
-    Prefers to rewrite only the specific slides named by the critic; falls back to the
-    full group when no individual slide numbers are provided or when all named slides are
-    outside the valid group range (i.e. the critic hallucinated out-of-bounds numbers).
+    Returns None when there is no overlap or when the issue has no non-empty
+    ``affected_slide_numbers`` (deck-split issues with empty lists are skipped).
+    Does not mutate the original *issue* dict in *results*.
     """
-    assignments: list[ReviewAssignment] = []
-    for result in results:
-        group = plan.slide_groups[result["group_idx"]]
-        chunk_ids = list(
+    raw = issue.get("affected_slide_numbers") or []
+    if not raw:
+        return None
+    clipped = [n for n in raw if n in group_slides]
+    if not clipped:
+        return None
+    out = dict(issue)
+    out["affected_slide_numbers"] = clipped
+    return out
+
+
+def _ordered_union_slide_numbers(issues: list[dict]) -> list[int]:
+    """Preserving first-seen order, union all ``affected_slide_numbers`` in *issues*."""
+    out: list[int] = []
+    seen: set[int] = set()
+    for iss in issues:
+        for n in iss.get("affected_slide_numbers", []):
+            if n not in seen:
+                seen.add(n)
+                out.append(n)
+    return out
+
+
+def _build_group_rewrite_assignment(
+    result: dict, plan: PresentationPlan, cycle_number: int
+) -> ReviewAssignment:
+    """One rewrite batch from a group-scoped critic result (``group_idx`` >= 0)."""
+    group = plan.slide_groups[result["group_idx"]]
+    chunk_ids = list(
+        dict.fromkeys(
+            cid for bp in group.slide_blueprints for cid in bp.source_chunk_ids
+        )
+    )
+    issues = result.get("issues", [])
+    valid_group_slides = set(result.get("target_slide_numbers", []))
+
+    all_have_slide_numbers = bool(issues) and all(
+        issue.get("affected_slide_numbers") for issue in issues
+    )
+
+    if all_have_slide_numbers:
+        affected = list(
             dict.fromkeys(
-                cid
-                for bp in group.slide_blueprints
-                for cid in bp.source_chunk_ids
+                n
+                for issue in issues
+                for n in issue["affected_slide_numbers"]
+                if n in valid_group_slides
             )
         )
-        issues = result.get("issues", [])
-        valid_group_slides = set(result.get("target_slide_numbers", []))
+        if not affected:
+            affected = list(result.get("target_slide_numbers", []))
+    else:
+        affected = list(result.get("target_slide_numbers", []))
 
-        all_have_slide_numbers = bool(issues) and all(
-            issue.get("affected_slide_numbers") for issue in issues
+    return {
+        "assignment_id": f"rewrite-{result['assignment_id']}",
+        "cycle_number": cycle_number,
+        "check_type": result["check_type"],
+        "scope_type": result["scope_type"],
+        "scope_id": result["scope_id"],
+        "group_idx": result["group_idx"],
+        "chunk_ids": chunk_ids,
+        "slide_blueprints": [bp.model_dump() for bp in group.slide_blueprints],
+        "target_slide_numbers": affected,
+        "rewrite_instructions": result.get("rewrite_instructions", ""),
+    }
+
+
+def _split_deck_result_into_rewrite_assignments(
+    result: dict, plan: PresentationPlan, cycle_number: int
+) -> list[ReviewAssignment]:
+    """Fan out a deck-scoped critic result (``group_idx == -1``) into one rewrite per affected group.
+
+    For each group, build per-writer issues by clipping ``affected_slide_numbers`` to that
+    group's slide set (a shallow copy; ``critic_results`` issue dicts are not mutated).
+    Rebuilds ``rewrite_instructions`` from the clipped copies only.
+    """
+    out: list[ReviewAssignment] = []
+    for group_idx, group in enumerate(plan.slide_groups):
+        group_slides = {bp.slide_number for bp in group.slide_blueprints}
+        clipped_issues: list[dict] = []
+        for issue in result.get("issues", []):
+            c = _clip_issue_to_group_slides(issue, group_slides)
+            if c is not None:
+                clipped_issues.append(c)
+        if not clipped_issues:
+            continue
+        chunk_ids = list(
+            dict.fromkeys(
+                cid for bp in group.slide_blueprints for cid in bp.source_chunk_ids
+            )
         )
-
-        if all_have_slide_numbers:
-            affected = list(dict.fromkeys(
-                n for issue in issues for n in issue["affected_slide_numbers"]
-                if n in valid_group_slides
-            ))
-            if not affected:
-                affected = result.get("target_slide_numbers", [])
-        else:
-            affected = result.get("target_slide_numbers", [])
-
-        assignments.append(
+        rewrite_lines = [
+            format_rewrite_instruction(iss)
+            for iss in clipped_issues
+            if str(iss.get("rewrite_instruction", "")).strip()
+        ]
+        rewrite_instructions = "\n".join(rewrite_lines)
+        target_slide_numbers = _ordered_union_slide_numbers(clipped_issues)
+        out.append(
             {
-                "assignment_id": f"rewrite-{result['assignment_id']}",
+                "assignment_id": f"rewrite-{result['assignment_id']}-g{group_idx}",
                 "cycle_number": cycle_number,
                 "check_type": result["check_type"],
                 "scope_type": result["scope_type"],
                 "scope_id": result["scope_id"],
-                "group_idx": result["group_idx"],
+                "group_idx": group_idx,
                 "chunk_ids": chunk_ids,
                 "slide_blueprints": [bp.model_dump() for bp in group.slide_blueprints],
-                "target_slide_numbers": affected,
-                "rewrite_instructions": result.get("rewrite_instructions", ""),
+                "target_slide_numbers": target_slide_numbers,
+                "rewrite_instructions": rewrite_instructions,
             }
         )
+    return out
+
+
+def _build_rewrite_assignments(
+    *, plan: PresentationPlan, results: list[dict], cycle_number: int
+) -> list[ReviewAssignment]:
+    """Build targeted rewrite ReviewAssignments from actionable critic results.
+
+    Group-scoped (grounding) results map 1:1. Deck-scoped narrative results
+    (``group_idx < 0``) are split per slide group with clipped slide numbers.
+    """
+    assignments: list[ReviewAssignment] = []
+    for result in results:
+        gidx = int(result.get("group_idx", 0))
+        if gidx < 0:
+            assignments.extend(
+                _split_deck_result_into_rewrite_assignments(result, plan, cycle_number)
+            )
+        else:
+            assignments.append(
+                _build_group_rewrite_assignment(result, plan, cycle_number)
+            )
     return assignments
 
 
@@ -193,6 +312,21 @@ class SupervisorAgent(BaseLLMAgent):
         severity_counts: dict[str, int] | None = None,
     ) -> Command:
         """Full replan: optional debug DB backup, then reset review and bump ``plan_number``."""
+        at_cycle_cap = cycle_number >= int(review.get("max_cycles", MAX_CYCLES))
+        should_force_accept = (
+            bool(state.get("force_accept_first_plan_at_cap"))
+            and at_cycle_cap
+            and int(state.get("plan_number", 1)) == 1
+        )
+        if should_force_accept:
+            fallback_counts = {"critical": 0, "major": 0, "minor": 0}
+            return self._force_accept_command(
+                state,
+                review,
+                cycle_number,
+                severity_counts or review.get("last_issue_counts", fallback_counts),
+            )
+
         plan = state.get("presentation_plan")
         plan_json: str | None
         if plan is not None:
@@ -247,6 +381,64 @@ class SupervisorAgent(BaseLLMAgent):
             goto="planner",
         )
 
+    def _accept_and_end(
+        self,
+        state: ResearchState,
+        review: dict,
+        plan_number: int,
+        cycle_number: int,
+        severity_counts: dict[str, int],
+        rewrites_required: dict[str, bool],
+    ) -> Command:
+        """Mark review complete, persist accept, emit summary, and route to END."""
+        review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
+        summary = {
+            "plan_number": plan_number,
+            "cycle_number": cycle_number,
+            "issue_counts": severity_counts,
+            "decision": "accept",
+            "routing": "accept",
+            "rewrites_required_by_assignment": rewrites_required,
+        }
+        with ResearchDatabase() as research_db:
+            research_db.save_review_event(
+                session_id=state["session_id"],
+                cycle_number=cycle_number,
+                plan_number=plan_number,
+                scope_type="deck",
+                scope_id="deck",
+                check_type="grounding_consistency",
+                decision="accept",
+            )
+        return Command(
+            update={
+                "review": review,
+                "review_summaries": [summary],
+                "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
+            },
+            goto=END,
+        )
+
+    def _force_accept_command(
+        self,
+        state: ResearchState,
+        review: dict,
+        cycle_number: int,
+        severity_counts: dict[str, int],
+    ) -> Command:
+        """At cap on plan 1, ``--force-accept-first-plan`` uses the same accept path as a normal accept."""
+        rewrites_required = dict(
+            review.get("last_rewrites_required_by_assignment") or {}
+        )
+        return self._accept_and_end(
+            state,
+            review,
+            int(state.get("plan_number", 1)),
+            cycle_number,
+            severity_counts,
+            rewrites_required,
+        )
+
     def run(self, state: ResearchState) -> Command:
         """Evaluate the current critic cycle and return the next routing Command."""
         self._set_session_id(state)
@@ -267,14 +459,21 @@ class SupervisorAgent(BaseLLMAgent):
             and at_cycle_cap
             and plan_number <= MAX_REPLANS
         )
-
         last_did = review.get("last_critic_dispatch_id")
         critic_results = [
             r
             for r in state.get("critic_results", [])
             if last_did and r.get("dispatch_id") == last_did
         ]
-        severity_counts = _severity_counts(critic_results)
+
+        # Aggregate issue counts by severity across all critic results for a single cycle.
+        severity_counts = {"critical": 0, "major": 0, "minor": 0}
+        for result in critic_results:
+            for issue in result.get("issues", []):
+                severity = issue.get("severity")
+                if severity in severity_counts:
+                    severity_counts[severity] += 1
+                    
         rewrites_required = {
             r["assignment_id"]: bool(r.get("actionable")) for r in critic_results
         }
@@ -363,14 +562,8 @@ class SupervisorAgent(BaseLLMAgent):
             next_cycle = max(1, cycle_number + 1)
             if at_cycle_cap and review.get("last_rewrite_assignment_ids"):
                 if plan_number <= MAX_REPLANS:
-                    return self._replan(
-                        state,
-                        review,
-                        cycle_number,
-                        severity_counts=review.get(
-                            "last_issue_counts", {"critical": 0, "major": 0, "minor": 0}
-                        ),
-                    )
+                    last_counts = review.get("last_issue_counts", {"critical": 0, "major": 0, "minor": 0})
+                    return self._replan(state, review, cycle_number, severity_counts=severity_counts)
                 last_counts = review.get("last_issue_counts", {"critical": 0, "major": 0, "minor": 0})
                 return end_after_replan_budget_gone(
                     last_counts,
@@ -381,7 +574,7 @@ class SupervisorAgent(BaseLLMAgent):
                     ),
                 )
 
-            assignments = _build_group_assignments(plan=plan, cycle_number=next_cycle)
+            assignments = _build_critic_assignments(plan=plan, cycle_number=next_cycle)
             review.update(
                 {
                     "cycle_number": next_cycle,
@@ -418,7 +611,7 @@ class SupervisorAgent(BaseLLMAgent):
                 )
 
             next_cycle = cycle_number + 1
-            assignments = _build_group_assignments(plan=plan, cycle_number=next_cycle)
+            assignments = _build_critic_assignments(plan=plan, cycle_number=next_cycle)
             review.update(
                 {
                     "cycle_number": next_cycle,
@@ -469,6 +662,7 @@ class SupervisorAgent(BaseLLMAgent):
         result: SupervisorOutput = self._call(
             [{"role": "user", "content": user}],
             schema=SupervisorOutput,
+            model="supervisor",
         )
         model_decision = result.decision
         # Return True if any actionable critic result contains at least one
@@ -557,22 +751,18 @@ class SupervisorAgent(BaseLLMAgent):
         )
 
         if decision == "replan":
-            return self._replan(state, review, cycle_number, result=result, severity_counts=severity_counts)
+            return self._replan(
+                state,
+                review,
+                cycle_number,
+                result=result,
+                severity_counts=severity_counts,
+            )
 
         if decision == "accept":
-            review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
-            updates["review"] = review
-            with ResearchDatabase() as research_db:
-                research_db.save_review_event(
-                    session_id=state["session_id"],
-                    cycle_number=cycle_number,
-                    plan_number=plan_number,
-                    scope_type="deck",
-                    scope_id="deck",
-                    check_type="grounding_consistency",
-                    decision="accept",
-                )
-            return Command(update=updates, goto=END)
+            return self._accept_and_end(
+                state, review, plan_number, cycle_number, severity_counts, rewrites_required
+            )
 
         rewrite_assignments = _build_rewrite_assignments(
             plan=plan,

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -127,8 +127,8 @@ groups:
 
   planner-fallback:
     models:
-      - "mistral/mistral-medium-2508"
       - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+      - "mistral/mistral-medium-2508"
     fallbacks:
       - "planner"
       - "fallback"
@@ -154,7 +154,7 @@ groups:
     models:
       - "mistral/magistral-medium-latest"
       - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
-      - "groq/meta-llama/llama-4-scout-17b-16e-instruct"
+      - "ollama/qwen3.5:397b-cloud"
     fallbacks:
       - "critic"
       - "fallback"
@@ -201,7 +201,6 @@ groups:
       - "mistral/mistral-medium-2508"
       - "mistral/magistral-medium-latest"
       - "ollama/minimax-m2.7:cloud"
-      - "groq/meta-llama/llama-4-scout-17b-16e-instruct"
       - "gemini/gemma-4-31b-it"
       - "ollama/gemma4:31b-cloud"
       - "groq/llama-3.3-70b-versatile"

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -54,7 +54,7 @@ providers:
     models:
       qwen3.5:397b-cloud:
         timeout: 240
-      minimax-m2.7:cloud: {}
+      minimax-m2.7:cloud: {}  # Tends to validation error
       gemma4:31b-cloud:
         max_parallel_requests: 5
       gemma3:4b-cloud:
@@ -116,28 +116,45 @@ groups:
     fallbacks:
       - "fallback"
 
-  slides:
-    models:
-      - "mistral/mistral-large-2411"
-      - "mistral/mistral-medium-2508"
-      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
-    fallbacks:
-      - "slides"
-      - "fallback"
-
   planner:
     models:
-      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+      - "mistral/magistral-medium-latest"
       - "ollama/qwen3.5:397b-cloud"
       - "mistral/mistral-large-2411"
     fallbacks:
       - "planner"
+      - "planner-fallback"
+
+  planner-fallback:
+    models:
+      - "mistral/mistral-medium-2508"
+      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+    fallbacks:
+      - "planner"
+      - "fallback"
+
+  supervisor:
+    models:
+      - "gemini/gemma-4-31b-it"
+      - "gemini/gemini-3.1-flash-lite-preview"
+    fallbacks:
+      - "supervisor"
+      - "fallback"
+
+  slides:
+    models:
+      - "mistral/mistral-large-2411"
+      - "mistral/mistral-medium-2508"
+      - "gemini/gemini-3.1-flash-lite-preview"
+    fallbacks:
+      - "slides"
+      - "fallback"
 
   critic:
     models:
-      - "ollama/minimax-m2.7:cloud"
       - "mistral/magistral-medium-latest"
-      - "gemini/gemini-3.1-flash-lite-preview"
+      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+      - "groq/meta-llama/llama-4-scout-17b-16e-instruct"
     fallbacks:
       - "critic"
       - "fallback"
@@ -149,6 +166,7 @@ groups:
       - "groq/meta-llama/llama-4-scout-17b-16e-instruct"
       - "mistral/mistral-medium-2505"
       - "mistral/ministral-14b-2512"
+      - "mistral/mistral-small-2603"
       - "gemini/gemini-3-flash-preview"
       - "gemini/gemini-2.5-flash"
       - "gemini/gemini-2.5-flash-lite"
@@ -166,11 +184,12 @@ groups:
 
   context:
     models:
+      - "gemini/gemma-4-31b-it"
       - "groq/llama-3.3-70b-versatile"
-      - "ollama/gemma3:27b-cloud"
-      - "ollama/gemma3:12b-cloud"
       - "openrouter/nvidia/nemotron-nano-12b-v2-vl:free"
       - "openrouter/openai/gpt-oss-120b:free"
+      - "ollama/gemma3:27b-cloud"
+      - "ollama/gemma3:12b-cloud"
     fallbacks:
       - "context"
       - "context-vision"
@@ -178,14 +197,16 @@ groups:
 
   fallback:
     models:
-      - "ollama/minimax-m2.7:cloud"
       - "mistral/mistral-large-2411"
       - "mistral/mistral-medium-2508"
       - "mistral/magistral-medium-latest"
-      - "groq/llama-3.3-70b-versatile"
+      - "ollama/minimax-m2.7:cloud"
       - "groq/meta-llama/llama-4-scout-17b-16e-instruct"
       - "gemini/gemma-4-31b-it"
       - "ollama/gemma4:31b-cloud"
+      - "groq/llama-3.3-70b-versatile"
+    fallbacks:
+      - "fallback"
 
 litellm:
   default_group: "app"

--- a/src/llm/config.sample.yaml
+++ b/src/llm/config.sample.yaml
@@ -99,6 +99,26 @@ providers:
       ministral-14b-2512:
         rpm: 30
 
+  nvidia_nim:
+    shared:
+      api_key: "os.environ/NVIDIA_NIM_API_KEY"
+    models:
+      deepseek-ai/deepseek-v4-flash:
+        rpm: 40
+      deepseek-ai/deepseek-v4-pro:
+        rpm: 40
+      deepseek-ai/deepseek-v3.2:
+        rpm: 40
+      z-ai/glm4.7: {}
+      nvidia/nemotron-4-340b-reward: {}
+      mistralai/mistral-large-3-675b-instruct-2512: {}
+      mistralai/mistral-medium-3-instruct: {}
+      mistralai/mistral-nemotron: {}
+      vlm/google/paligemma: {}
+      google/gemma-3-27b-it: {}
+      microsoft/phi-3.5-vision-instruct: {}
+      microsoft/phi-4-multimodal-instruct: {}
+
   groq:
     shared:
       api_key: "os.environ/GROQ_API_KEY"
@@ -127,8 +147,8 @@ groups:
 
   planner-fallback:
     models:
-      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
       - "mistral/mistral-medium-2508"
+      - "openrouter/nvidia/nemotron-3-super-120b-a12b:free"
     fallbacks:
       - "planner"
       - "fallback"
@@ -203,7 +223,6 @@ groups:
       - "ollama/minimax-m2.7:cloud"
       - "gemini/gemma-4-31b-it"
       - "ollama/gemma4:31b-cloud"
-      - "groq/llama-3.3-70b-versatile"
     fallbacks:
       - "fallback"
 

--- a/src/processing/context/contextualizer.py
+++ b/src/processing/context/contextualizer.py
@@ -378,7 +378,8 @@ class Contextualizer:
                                 f"Surrounding text:\n<before>{text_before}</before>\n"
                                 f"<after>{text_after}</after>\n\n"
                                 f"[IMAGE]: The image shows: {image.caption}\n\n"
-                                "Provide a succinct context in 1 paragraph, no more than 5 sentences describing this image's role and specific position within the document.\n"
+                                "Provide a succinct context no more than 3 paragraphs, no more than 15 sentences total describing this image's role in the paper and what it shows.\n"
+                                "Be specific and detailed, and do not use bullets, labels, or markdown headings.\n"
                                 "Focus on how the surrounding narrative frames this image and what information it conveys.\n"
                     },
                     {

--- a/src/processing/document/backends/llama_parse_backend.py
+++ b/src/processing/document/backends/llama_parse_backend.py
@@ -300,7 +300,6 @@ class LlamaParseBackend(OCRBackend):
                     f"[LlamaParseBackend] Parse still in progress job_id={job_id} "
                     f"elapsed={elapsed}s (waiting on LlamaCloud)…"
                 )
-                print(msg, flush=True)
                 self._logger.log(msg, level="info")
 
         hb = threading.Thread(target=_heartbeat, name=f"llamaparse-wait-{job_id[:8]}", daemon=True)
@@ -415,7 +414,6 @@ class LlamaParseBackend(OCRBackend):
                             raise RuntimeError("LlamaParse create did not return job id.")
                         self._wait_parse_job_with_status(job_id)
                         done_msg = f"[LlamaParseBackend] Parse job finished job_id={job_id}, fetching result…"
-                        print(done_msg, flush=True)
                         self._logger.log(done_msg, level="info")
                         result = self._client.parsing.get(job_id, expand=_PARSE_EXPAND)
                         return result, job_id

--- a/src/state.py
+++ b/src/state.py
@@ -42,8 +42,8 @@ Prevents unbounded plan → review → discard → plan loops while still allowi
 ReviewScopeType = Literal["deck", "group", "slide"]
 """Granularity at which a critic or rewrite assignment targets slides."""
 
-ReviewCheckType = Literal["grounding_consistency"]
-"""Kind of quality check being performed.  Currently only grounding/consistency is implemented."""
+ReviewCheckType = Literal["grounding_consistency", "narrative_coherence"]
+"""Kind of quality check (e.g. grounding vs deck narrative coherence)."""
 
 ReviewDispatchKind = Literal["initial_write", "critic", "rewrite"]
 """Which dispatch phase an ``ActiveDispatch`` belongs to."""
@@ -289,9 +289,9 @@ class ReviewAssignment(TypedDict):
 
 
 class ActiveDispatch(TypedDict):
-    """Tracks the single in-flight batch of assignments the Supervisor is waiting on.
+    """Tracks the single in-flight batch of assignments the Plan Executor is waiting on.
 
-    Only one ``ActiveDispatch`` exists at a time.  The Supervisor sets this when
+    Only one ``ActiveDispatch`` exists at a time.  The Plan Executor sets this when
     it fans out a set of assignments and clears it once all expected results have
     arrived in ``ResearchState``.
 
@@ -318,7 +318,7 @@ class ActiveDispatch(TypedDict):
 class SlideWriteRecord(TypedDict):
     """Immutable record appended to ``ResearchState.slides_written`` when a Slide Writer completes.
 
-    Used by the Supervisor to detect when all slides in a dispatch batch have
+    Used by the Plan Executor to detect when all slides in a dispatch batch have
     been written, and to audit which group/assignment each write belongs to.
 
     Fields
@@ -347,6 +347,9 @@ class CriticIssueRecord(TypedDict):
     """A single actionable quality issue identified by the Slide Critic.
 
     Stored inside ``CriticResultRecord.issues``.
+    Needs to be separate from CriticIssue in slide_critic.py because it also contains a
+    fingerprint field, which should not be passed to the llm (which the CriticIssue class 
+    is in its entirety)
 
     Fields
     ------
@@ -381,7 +384,7 @@ class CriticResultRecord(TypedDict):
     """Complete output of one Slide Critic invocation, appended to ``ResearchState.critic_results``.
 
     One record is produced per critic assignment.  The Supervisor reads these
-    records to decide whether to accept the deck, trigger rewrites, or replan.
+    records to decide whether to accept the deck, trigger rewrites, or replan. 
 
     Fields
     ------

--- a/src/state.py
+++ b/src/state.py
@@ -401,7 +401,9 @@ class CriticResultRecord(TypedDict):
     scope_id:
         Human-readable label for the scope.
     group_idx:
-        Zero-based index of the slide group that was reviewed.
+        Zero-based index of the slide group that was reviewed. Use ``-1`` for a
+        deck-scoped critic assignment (e.g. narrative coherence over the full deck);
+        such results are split into per-group rewrite work by the supervisor.
     target_slide_numbers:
         Slide numbers that were in scope for this critique.
     actionable:
@@ -627,6 +629,10 @@ class ResearchState(TypedDict):
         Test-only: when true, first ``MAX_REPLANS`` times the supervisor is at
         the critic/rewrite cap, force ``replan`` so the test harness can
         exercise replan without LLM choice.
+    force_accept_first_plan_at_cap:
+        When true, if the critic/rewrite cap is reached on plan 1 and the
+        supervisor would replan or halt without export, force acceptance and
+        proceed to export instead.
 
     Append-only execution records
     -----------------------------
@@ -673,6 +679,7 @@ class ResearchState(TypedDict):
     skip_supervisor: bool
     plan_number: int
     force_replan_at_max_cycles: bool
+    force_accept_first_plan_at_cap: bool
 
     # -- presentation plan (set by Planner, read by Plan Executor + Slide Writers) --
     presentation_plan: Optional[PresentationPlan]

--- a/tests/test_supervisor_narrative.py
+++ b/tests/test_supervisor_narrative.py
@@ -1,0 +1,206 @@
+"""Unit tests for narrative critic dispatch and deck-scoped rewrite splitting (no LLM / DB)."""
+
+from __future__ import annotations
+
+import unittest
+
+from src.agents.supervisor import (
+    _build_critic_assignments,
+    _build_rewrite_assignments,
+)
+from src.state import (
+    SlideBlueprint,
+    SlideGroup,
+    PresentationPlan,
+)
+
+
+def _bp(n: int) -> SlideBlueprint:
+    return SlideBlueprint(
+        slide_number=n,
+        working_title=f"t{n}",
+        narrative_role="hook",
+        intent="i",
+        source_chunk_ids=["c1"],
+    )
+
+
+def _minimal_plan_one_group() -> PresentationPlan:
+    return PresentationPlan(
+        title="T",
+        subtitle="S",
+        thesis="th",
+        target_audience="all",
+        estimated_duration_minutes=5,
+        narrative_arc_summary="arc",
+        slide_groups=[SlideGroup(slide_blueprints=[_bp(1)], rationale="r")],
+        reasoning="plan",
+    )
+
+
+def _plan_two_groups_12_34() -> PresentationPlan:
+    return PresentationPlan(
+        title="T",
+        subtitle="S",
+        thesis="th",
+        target_audience="all",
+        estimated_duration_minutes=5,
+        narrative_arc_summary="arc",
+        slide_groups=[
+            SlideGroup(slide_blueprints=[_bp(1), _bp(2)], rationale="g0"),
+            SlideGroup(slide_blueprints=[_bp(3), _bp(4)], rationale="g1"),
+        ],
+        reasoning="plan",
+    )
+
+
+class TestNarrativeCriticWiring(unittest.TestCase):
+    def test_critic_assignments_include_grounding_and_narrative(self) -> None:
+        plan = _minimal_plan_one_group()
+        a = _build_critic_assignments(plan=plan, cycle_number=1)
+        self.assertEqual(len(a), 2)
+        self.assertEqual(a[0]["check_type"], "grounding_consistency")
+        self.assertEqual(a[0]["group_idx"], 0)
+        self.assertEqual(a[1]["check_type"], "narrative_coherence")
+        self.assertEqual(a[1]["group_idx"], -1)
+        self.assertEqual(a[1]["scope_type"], "deck")
+        self.assertEqual(a[1]["assignment_id"], "critic-c1-narrative")
+        self.assertEqual(a[1]["chunk_ids"], [])
+
+    def test_deck_result_splits_and_clips_slide_numbers(self) -> None:
+        plan = _plan_two_groups_12_34()
+        deck = {
+            "dispatch_id": "critic-1",
+            "assignment_id": "critic-c1-narrative",
+            "cycle_number": 1,
+            "check_type": "narrative_coherence",
+            "scope_type": "deck",
+            "scope_id": "deck",
+            "group_idx": -1,
+            "target_slide_numbers": [1, 2, 3, 4],
+            "actionable": True,
+            "rewrite_instructions": "ignored",
+            "summary": "s",
+            "issues": [
+                {
+                    "issue_code": "I1",
+                    "severity": "major",
+                    "issue_type": "flow",
+                    "location": "l",
+                    "fingerprint": "f1",
+                    "affected_slide_numbers": [2, 3, 4],
+                    "rewrite_instruction": "fix transition",
+                }
+            ],
+        }
+        rewrites = _build_rewrite_assignments(
+            plan=plan, results=[deck], cycle_number=1
+        )
+        self.assertEqual(len(rewrites), 2)
+        r0 = next(r for r in rewrites if r["group_idx"] == 0)
+        r1 = next(r for r in rewrites if r["group_idx"] == 1)
+        self.assertEqual(r0["target_slide_numbers"], [2])
+        self.assertIn("Slide(s) 2", r0["rewrite_instructions"])
+        self.assertEqual(r1["target_slide_numbers"], [3, 4])
+        self.assertIn("Slide(s) 3, 4", r1["rewrite_instructions"])
+
+    def test_deck_issue_non_overlapping_group_gets_no_rewrite(self) -> None:
+        plan = _plan_two_groups_12_34()
+        deck = {
+            "dispatch_id": "critic-1",
+            "assignment_id": "critic-c1-narrative",
+            "cycle_number": 1,
+            "check_type": "narrative_coherence",
+            "scope_type": "deck",
+            "scope_id": "deck",
+            "group_idx": -1,
+            "target_slide_numbers": [1, 2, 3, 4],
+            "actionable": True,
+            "rewrite_instructions": "",
+            "summary": "s",
+            "issues": [
+                {
+                    "issue_code": "I1",
+                    "severity": "major",
+                    "issue_type": "flow",
+                    "location": "l",
+                    "fingerprint": "f1",
+                    "affected_slide_numbers": [5, 6],
+                    "rewrite_instruction": "n/a",
+                }
+            ],
+        }
+        rewrites = _build_rewrite_assignments(
+            plan=plan, results=[deck], cycle_number=1
+        )
+        self.assertEqual(rewrites, [])
+
+    def test_deck_skips_empty_affected_slide_numbers(self) -> None:
+        plan = _plan_two_groups_12_34()
+        deck = {
+            "dispatch_id": "critic-1",
+            "assignment_id": "critic-c1-narrative",
+            "cycle_number": 1,
+            "check_type": "narrative_coherence",
+            "scope_type": "deck",
+            "scope_id": "deck",
+            "group_idx": -1,
+            "target_slide_numbers": [1, 2, 3, 4],
+            "actionable": True,
+            "rewrite_instructions": "",
+            "summary": "s",
+            "issues": [
+                {
+                    "issue_code": "I1",
+                    "severity": "major",
+                    "issue_type": "flow",
+                    "location": "l",
+                    "fingerprint": "f1",
+                    "affected_slide_numbers": [],
+                    "rewrite_instruction": "x",
+                }
+            ],
+        }
+        rewrites = _build_rewrite_assignments(
+            plan=plan, results=[deck], cycle_number=1
+        )
+        self.assertEqual(rewrites, [])
+
+    def test_group_scoped_grounding_rewrite_unchanged_shape(self) -> None:
+        plan = _minimal_plan_one_group()
+        g = {
+            "dispatch_id": "critic-1",
+            "assignment_id": "critic-c1-g0",
+            "cycle_number": 1,
+            "check_type": "grounding_consistency",
+            "scope_type": "group",
+            "scope_id": "0",
+            "group_idx": 0,
+            "target_slide_numbers": [1],
+            "actionable": True,
+            "rewrite_instructions": "fix it",
+            "summary": "s",
+            "issues": [
+                {
+                    "issue_code": "I1",
+                    "severity": "major",
+                    "issue_type": "g",
+                    "location": "l",
+                    "fingerprint": "f1",
+                    "affected_slide_numbers": [1],
+                    "rewrite_instruction": "cite",
+                }
+            ],
+        }
+        rewrites = _build_rewrite_assignments(
+            plan=plan, results=[g], cycle_number=1
+        )
+        self.assertEqual(len(rewrites), 1)
+        self.assertEqual(rewrites[0]["assignment_id"], "rewrite-critic-c1-g0")
+        self.assertEqual(rewrites[0]["group_idx"], 0)
+        self.assertEqual(rewrites[0]["target_slide_numbers"], [1])
+        self.assertEqual(rewrites[0]["rewrite_instructions"], "fix it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supervisor_replan.py
+++ b/tests/test_supervisor_replan.py
@@ -332,5 +332,105 @@ class TestSupervisorReplan(unittest.TestCase):
         mock_backup.assert_called_once()
 
 
+class TestForceAcceptFirstPlan(unittest.TestCase):
+    """Tests for --force-accept-first-plan: at cap on plan 1, replan/reject → accept+export."""
+
+    @patch("src.agents.supervisor.backup_replan_debug_snapshot")
+    @patch("src.agents.supervisor.ResearchDatabase")
+    def test_no_critic_batch_rewrites_pending_exports(
+        self, mock_db_class: MagicMock, mock_backup: MagicMock
+    ) -> None:
+        """No critic batch yet, at cap, rewrites pending, plan 1 → force accept, goto END."""
+        mock_ctx, mock_db = _patch_db_and_backup()
+        mock_db_class.return_value = mock_ctx
+
+        review = make_initial_review_state(max_cycles=MAX_CYCLES)
+        review["cycle_number"] = MAX_CYCLES
+        review["last_rewrite_assignment_ids"] = ["rewrite-x"]
+        review["dispatch_counter"] = 7
+
+        state = {
+            "session_id": "sess",
+            "query": "q",
+            "plan_number": 1,
+            "force_replan_at_max_cycles": False,
+            "force_accept_first_plan_at_cap": True,
+            "presentation_plan": _minimal_presentation_plan(),
+            "review": review,
+            "critic_results": [],
+            "review_summaries": [],
+        }
+        cmd = SupervisorAgent().run(state)
+
+        from langgraph.graph import END as _END
+        self.assertEqual(cmd.goto, _END)
+        self.assertTrue(cmd.update["review"]["export_ready"])
+        self.assertEqual(cmd.update["review"]["final_decision"], "accept")
+        s0 = cmd.update["review_summaries"][0]
+        self.assertEqual(s0["decision"], "accept")
+        self.assertEqual(s0["routing"], "accept")
+        mock_backup.assert_not_called()
+
+    @patch("src.agents.supervisor.backup_replan_debug_snapshot")
+    @patch("src.agents.supervisor.ResearchDatabase")
+    def test_force_accept_wins_over_force_replan(
+        self, mock_db_class: MagicMock, mock_backup: MagicMock
+    ) -> None:
+        """Both flags set: force-accept-first-plan wins and exports instead of replanning."""
+        mock_ctx, mock_db = _patch_db_and_backup()
+        mock_db_class.return_value = mock_ctx
+
+        review = make_initial_review_state(max_cycles=MAX_CYCLES)
+        review["cycle_number"] = MAX_CYCLES
+        review["last_rewrite_assignment_ids"] = ["rewrite-y"]
+
+        state = {
+            "session_id": "sess",
+            "query": "q",
+            "plan_number": 1,
+            "force_replan_at_max_cycles": True,
+            "force_accept_first_plan_at_cap": True,
+            "presentation_plan": _minimal_presentation_plan(),
+            "review": review,
+            "critic_results": [],
+            "review_summaries": [],
+        }
+        cmd = SupervisorAgent().run(state)
+
+        from langgraph.graph import END as _END
+        self.assertEqual(cmd.goto, _END)
+        self.assertTrue(cmd.update["review"]["export_ready"])
+        mock_backup.assert_not_called()
+
+    @patch("src.agents.supervisor.backup_replan_debug_snapshot")
+    @patch("src.agents.supervisor.ResearchDatabase")
+    def test_plan2_not_affected(
+        self, mock_db_class: MagicMock, mock_backup: MagicMock
+    ) -> None:
+        """Flag set but plan_number=2: normal replan still happens (flag only covers plan 1)."""
+        mock_ctx, mock_db = _patch_db_and_backup()
+        mock_db_class.return_value = mock_ctx
+
+        review = make_initial_review_state(max_cycles=MAX_CYCLES)
+        review["cycle_number"] = MAX_CYCLES
+        review["last_rewrite_assignment_ids"] = ["rewrite-z"]
+
+        state = {
+            "session_id": "sess",
+            "query": "q",
+            "plan_number": 2,
+            "force_replan_at_max_cycles": False,
+            "force_accept_first_plan_at_cap": True,
+            "presentation_plan": _minimal_presentation_plan(),
+            "review": review,
+            "critic_results": [],
+            "review_summaries": [],
+        }
+        cmd = SupervisorAgent().run(state)
+
+        self.assertEqual(cmd.goto, "planner")
+        self.assertEqual(cmd.update["plan_number"], 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Critic prompts changed to be modular with review criteria.
Corrected a few incorrect comments in state.py.
Contextualizer uses 15 sentences now to describe images.
Removed doubled llamaparse log output.
Added forced accept commandline toggle (for debug purposes only).
Narrative critic implemented and wired.
Removed working title from re-writer prompts.
Instructed critic to ignore "key message" field.
Added fallback fallback to fallback in config.yaml.
Added nvidia_nim key field to .env.sample.