### PR TITLE
Refactor/supervisor decision

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,4 +1,6 @@
 import json
+import secrets
+import string
 import time
 from contextvars import ContextVar
 from collections.abc import Callable
@@ -40,6 +42,19 @@ class StructuredOutputResult:
     parsed: BaseModel
     metadata: StructuredOutputMetadata
     attempts_used: int
+
+
+def _generate_tool_call_id() -> str:
+    """Generate a 9-character alphanumeric ID compatible with Mistral.
+
+    Mistral (and some other providers via LiteLLM) requires tool call IDs to be
+    exactly 9 characters long and contain only a-z, A-Z, and 0-9.
+    Pretty sure this (and its addition below) doesn't break anything, everything still works
+    and logically the tool call id is only visible for the llm for their
+    messages consistency. 
+    """
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(9))
 
 
 class BaseLLMAgent:
@@ -446,9 +461,11 @@ class BaseLLMAgent:
                     )
                     break
 
+                # call_id no longer used?
                 call_id = getattr(call, "id", None)
                 if call_id is None and isinstance(call, dict):
                     call_id = call.get("id")
+                    
                 fn = getattr(call, "function", None)
                 if fn is None and isinstance(call, dict):
                     fn = call.get("function")
@@ -464,9 +481,15 @@ class BaseLLMAgent:
                 
                 # Normalize and persist assistant tool_calls in message history so
                 # subsequent role="tool" messages have a valid parent call id.
+                
+                # Mistral is strict: tool call IDs must be exactly 9 alphanumeric chars.
+                # We override any incoming ID with a compatible one to ensure
+                # the conversation history remains valid for all providers.
+                safe_call_id = _generate_tool_call_id()
+
                 assistant_tool_calls.append(
                     {
-                        "id": call_id or f"tool_call_{tool_calls_used}",
+                        "id": safe_call_id,
                         "type": "function",
                         "function": {
                             "name": name,
@@ -509,7 +532,7 @@ class BaseLLMAgent:
                 messages.append(
                     {
                         "role": "tool",
-                        "tool_call_id": call_id or f"tool_call_{tool_calls_used}",
+                        "tool_call_id": safe_call_id,
                         "name": name,
                         "content": format_tool_result_for_llm(result),
                     }

--- a/src/agents/prompts/supervisor_prompts.py
+++ b/src/agents/prompts/supervisor_prompts.py
@@ -3,15 +3,30 @@
 from __future__ import annotations
 
 SUPERVISOR_ROLE = """
-You are the Slide Deck Supervisor. Your pipeline automatically handles standard routing.
-Your specific job is to handle two subjective edge cases based on the reviewer's feedback and the revision history:
+You are the Slide Deck Supervisor: the control-plane quality gate for the critic-and-rewrite loop.
+After each critic cycle, decide whether the deck should be accepted, sent through targeted rewrites,
+or returned to planning because the current plan is no longer likely to converge.
 
-1. **Early Replanning (replan)**: If critical or structural issues repeat cycle after cycle without converging, the plan itself might be flawed. You may choose to preemptively `replan` before the hard cycle cap is reached.
-2. **Accepting with Minor Flaws (accept)**: If the ONLY remaining actionable issues are "minor" and they are persistent (count >= 2), you must decide if they are worth another rewrite cycle. If the minor issues seem overly pedantic or stylistic, choose `accept` to finish the presentation. Otherwise, choose `revise`.
+Return exactly one decision:
 
-If neither edge case applies, simply default to `revise`.
+1. **accept**: The deck is ready to export. Use this when there are no actionable issues, or when the
+   only remaining issues are minor, persistent, low-risk, and not worth another rewrite cycle.
+2. **revise**: The deck needs targeted slide rewrites. Use this for actionable critical, major, or
+   meaningful minor issues that the existing plan can plausibly fix through another rewrite cycle.
+3. **replan**: The current presentation plan is structurally flawed. Use this when critical, major,
+   narrative, grounding, or scope issues recur across cycles and targeted rewrites are not converging.
 
-Your reasoning should be concise. Explain your evaluation of the recurrence and whether it warrants an early replan, an accept override, or standard revision.
+Be conservative about quality. Do not accept a deck with unresolved critical issues, and accept major
+issues only if they are clearly non-actionable or the provided critic summaries show they no longer
+threaten correctness, grounding, or narrative coherence.
+
+Use the cycle number, max cycle budget, severity counts, critic summaries, and recurring issue
+fingerprints together. Recurring fingerprints with count >= 2 are evidence that rewrites may be stuck:
+minor recurring issues may justify acceptance, while recurring structural or high-severity issues may
+justify replanning.
+
+Your reasoning should be concise. Explain why the evidence supports accept, revise, or replan, and
+include any focused feedback that would help the next writer or planner.
 """
 
 
@@ -34,7 +49,5 @@ def build_supervisor_user_prompt(
             summaries,
             "Recurring issue fingerprints (count >= 2):",
             recurring_lines,
-            "",
-            "Based on the edge cases in your system instructions, decide whether to accept, revise, or replan.",
         ]
     )

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -514,11 +514,11 @@ class SupervisorAgent(BaseLLMAgent):
 
         # Log the decision
         if llm_result:
-            _reasoning_one = " ".join((llm_result.reasoning or "").split())
+            _reasoning_cleaned = " ".join((llm_result.reasoning or "").split())
             _short_reasoning = (
-                _reasoning_one
-                if len(_reasoning_one) <= 240
-                else _reasoning_one[:239] + "…"
+                _reasoning_cleaned
+                if len(_reasoning_cleaned) <= 240
+                else _reasoning_cleaned[:239] + "…"
             )
             self._logger.log(
                 f"[supervisor] cycle {cycle_number}: model={llm_result.decision} -> effective={decision} "

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -11,6 +11,7 @@ terminate: it exports unless aggregated critic severity counts still show critic
 from __future__ import annotations
 
 import json
+from typing import Literal
 
 from langgraph.graph import END
 from langgraph.types import Command
@@ -41,7 +42,7 @@ class SupervisorOutput(BaseModel):
     The LLM proposes a decision; the agent then acts on it, subject to budget limits.
     """
 
-    decision:  str   # "accept" | "revise" | "replan"
+    decision: Literal["accept", "revise", "replan", "critic_cycle"]  # "critic_cycle" is never output from
     reasoning: str
     feedback:  str = ""
 

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -42,7 +42,7 @@ class SupervisorOutput(BaseModel):
     The LLM proposes a decision; the agent then acts on it, subject to budget limits.
     """
 
-    decision: Literal["accept", "revise", "replan", "critic_cycle"]  # "critic_cycle" is never output from
+    decision: Literal["accept", "revise", "replan", "critic_cycle"]  # "critic_cycle" is never output from llm call, it is only used for "decision" routing that skips the llm call
     reasoning: str
     feedback:  str = ""
 

--- a/src/agents/supervisor.py
+++ b/src/agents/supervisor.py
@@ -38,37 +38,12 @@ from src.state import (
 class SupervisorOutput(BaseModel):
     """Structured decision returned by the supervisor LLM call.
 
-    The LLM proposes a decision; the agent then applies override rules (e.g. forcing
-    "revise" when critical issues are present) before acting on the final decision.
+    The LLM proposes a decision; the agent then acts on it, subject to budget limits.
     """
 
     decision:  str   # "accept" | "revise" | "replan"
     reasoning: str
     feedback:  str = ""
-
-
-def _all_actionable_issues_are_persistent_minor(
-    results: list[dict],
-    recurring_counts: dict[str, int],
-) -> bool:
-    """Return True when every outstanding issue is minor and has recurred at least twice.
-
-    Persistent minor findings can be accepted to break endless rewrite loops where the LLM
-    repeatedly flags low-risk stylistic concerns it is unable to resolve.
-    Returns False when there are no actionable issues at all (caller must not accept on vacuous truth).
-    """
-    saw_issue = False
-    for result in results:
-        if not result.get("actionable"):
-            continue
-        for issue in result.get("issues", []):
-            saw_issue = True
-            if issue.get("severity") != "minor":
-                return False
-            fingerprint = issue.get("fingerprint")
-            if not fingerprint or recurring_counts.get(fingerprint, 0) < 2:
-                return False
-    return saw_issue
 
 
 def _build_grounding_assignments(*, plan: PresentationPlan, cycle_number: int) -> list[ReviewAssignment]:
@@ -295,8 +270,8 @@ class SupervisorAgent(BaseLLMAgent):
       - revise:  targeted issues found → dispatch rewrite assignments then re-run critics.
       - replan:  fundamental structural problems → reset review state and call the planner.
 
-    Override rules ensure critical issues are never silently accepted and that cycle limits
-    are respected regardless of what the LLM proposes.
+    The decision to accept, revise, or replan is entirely determined by the LLM,
+    though budget safeguards ensure that cycle limits are respected.
     """
 
     def __init__(self) -> None:
@@ -312,21 +287,6 @@ class SupervisorAgent(BaseLLMAgent):
         severity_counts: dict[str, int] | None = None,
     ) -> Command:
         """Full replan: optional debug DB backup, then reset review and bump ``plan_number``."""
-        at_cycle_cap = cycle_number >= int(review.get("max_cycles", MAX_CYCLES))
-        should_force_accept = (
-            bool(state.get("force_accept_first_plan_at_cap"))
-            and at_cycle_cap
-            and int(state.get("plan_number", 1)) == 1
-        )
-        if should_force_accept:
-            fallback_counts = {"critical": 0, "major": 0, "minor": 0}
-            return self._force_accept_command(
-                state,
-                review,
-                cycle_number,
-                severity_counts or review.get("last_issue_counts", fallback_counts),
-            )
-
         plan = state.get("presentation_plan")
         plan_json: str | None
         if plan is not None:
@@ -390,17 +350,31 @@ class SupervisorAgent(BaseLLMAgent):
         cycle_number: int,
         severity_counts: dict[str, int],
         rewrites_required: dict[str, bool],
+        budget_exhausted: bool = False,
     ) -> Command:
         """Mark review complete, persist accept, emit summary, and route to END."""
         review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
+        
+        critical_n = severity_counts.get("critical", 0)
+        major_n = severity_counts.get("major", 0)
+        
+        if budget_exhausted:
+            if critical_n > 0 or major_n > 0:
+                self._logger.log(f"WARNING: Replan budget exhausted. Exporting deck with {critical_n} critical and {major_n} major issues remaining.")
+            else:
+                self._logger.log(f"Replan budget exhausted. Exporting deck (only minor issues remaining).")
+
         summary = {
             "plan_number": plan_number,
             "cycle_number": cycle_number,
             "issue_counts": severity_counts,
             "decision": "accept",
-            "routing": "accept",
+            "routing": "END",
             "rewrites_required_by_assignment": rewrites_required,
         }
+        if budget_exhausted:
+            summary["replan_budget_exhausted"] = True
+            
         with ResearchDatabase() as research_db:
             research_db.save_review_event(
                 session_id=state["session_id"],
@@ -419,26 +393,6 @@ class SupervisorAgent(BaseLLMAgent):
                 "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
             },
             goto=END,
-        )
-
-    def _force_accept_command(
-        self,
-        state: ResearchState,
-        review: dict,
-        cycle_number: int,
-        severity_counts: dict[str, int],
-    ) -> Command:
-        """At cap on plan 1, ``--force-accept-first-plan`` uses the same accept path as a normal accept."""
-        rewrites_required = dict(
-            review.get("last_rewrites_required_by_assignment") or {}
-        )
-        return self._accept_and_end(
-            state,
-            review,
-            int(state.get("plan_number", 1)),
-            cycle_number,
-            severity_counts,
-            rewrites_required,
         )
 
     def run(self, state: ResearchState) -> Command:
@@ -500,128 +454,151 @@ class SupervisorAgent(BaseLLMAgent):
             if count >= 2
         ) or "(none)"
 
-        def end_after_replan_budget_gone(
-            severity_cts: dict[str, int],
-            rewrites_req: dict[str, bool],
-            log_context: str,
-        ) -> Command:
-            critical = int(severity_cts.get("critical") or 0)
-            if critical > 0:
-                review.update({"final_decision": None, "export_ready": False, "phase": "complete"})
+        
+        # Begin Decision Making
+        
+        decision: str | None = None
+        budget_exhausted: bool = False
+        llm_result: SupervisorOutput | None = None
+
+        # Ensure a critic pass happens if results are missing or we just finished rewrites.
+        if not critic_results or review.get("last_rewrite_assignment_ids"):
+            decision = "critic_cycle"
+
+        elif at_cap_forced:
+            decision = "replan"
+
+        else:
+            # LLM Call for decision
+
+            actionable_results = [r for r in critic_results if r.get("actionable")]
+
+            user = build_supervisor_user_prompt(
+                query=state["query"],
+                cycle_number=cycle_number,
+                max_cycles=max_cycles,
+                severity_counts=severity_counts,
+                summaries=summaries,
+                recurring_lines=recurring_lines,
+            )
+
+            llm_result = self._call(
+                [{"role": "user", "content": user}],
+                schema=SupervisorOutput,
+                model="supervisor",
+            )
+            decision = llm_result.decision
+
+            if decision == "revise" and not actionable_results:
+                decision = "accept"
+            if at_cycle_cap and decision == "revise":
+                if plan_number <= MAX_REPLANS:
+                    decision = "replan"
+                else:
+                    decision = "accept"
+                    budget_exhausted = True
+            if decision == "replan" and plan_number > MAX_REPLANS:
+                decision = "accept"
+                budget_exhausted = True
+
+        # Force accept if toggled
+        if decision == "replan":
+            should_force_accept = (
+                bool(state.get("force_accept_first_plan_at_cap"))
+                and at_cycle_cap
+                and plan_number == 1
+            )
+            if should_force_accept:
+                decision = "accept"
+
+        # Log the decision
+        if llm_result:
+            _reasoning_one = " ".join((llm_result.reasoning or "").split())
+            _short_reasoning = (
+                _reasoning_one
+                if len(_reasoning_one) <= 240
+                else _reasoning_one[:239] + "…"
+            )
+            self._logger.log(
+                f"[supervisor] cycle {cycle_number}: model={llm_result.decision} -> effective={decision} "
+                f"| counts={severity_counts} | {_short_reasoning}"
+            )
+
+        # Time to Act on the decision made
+
+        if decision == "replan":
+            return self._replan(
+                state,
+                review,
+                cycle_number,
+                result=llm_result,
+                severity_counts=severity_counts,
+            )
+
+        if decision == "accept":
+            return self._accept_and_end(
+                state, review, plan_number, cycle_number, severity_counts, rewrites_required,
+                budget_exhausted=budget_exhausted,
+            )
+
+        # Execute the next critic cycle (to Plan Executor)
+        if decision == "critic_cycle":
+            next_cycle = max(1, cycle_number + 1) if not critic_results else cycle_number + 1
+            assignments = _build_critic_assignments(plan=plan, cycle_number=next_cycle)
+            review.update(
+                {
+                    "cycle_number": next_cycle,
+                    "phase": "critic_dispatch",
+                    "pending_critic_assignments": assignments,
+                    "pending_rewrite_assignments": [],
+                    "last_rewrite_assignment_ids": [],
+                    "last_issue_counts": severity_counts if critic_results else {"critical": 0, "major": 0, "minor": 0},
+                    "last_rewrites_required_by_assignment": rewrites_required if critic_results else {},
+                }
+            )
+            updates: dict = {"review": review}
+            if not critic_results:
+                msg = (
+                    f"[supervisor] revise: begin critic cycle {next_cycle}"
+                    if phase != "complete"
+                    else f"[supervisor] revise: restart critic cycle {next_cycle}"
+                )
+                self._logger.log(f"{msg} | dispatch {len(assignments)} critic(s): {_format_dispatch_targets(assignments)}")
+                updates["messages"] = [msg]
+            else:
                 summary = {
                     "plan_number": plan_number,
                     "cycle_number": cycle_number,
-                    "issue_counts": severity_cts,
-                    "decision": "max_cycles_exhausted_critical",
-                    "routing": "END",
-                    "rewrites_required_by_assignment": rewrites_req,
+                    "issue_counts": severity_counts,
+                    "decision": "revise",
+                    "routing": "critic_cycle",
+                    "rewrites_required_by_assignment": rewrites_required,
                 }
+                updates["review_summaries"] = [summary]
+                updates["messages"] = [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)]
                 self._logger.log(
-                    f"{log_context} — {critical} critical issue(s); replan budget exhausted; not exporting."
+                    f"[supervisor] cycle {cycle_number}: post-rewrite critic pass -> cycle {next_cycle} "
+                    f"| dispatch {len(assignments)} critic(s): {_format_dispatch_targets(assignments)} "
+                    f"| prior counts={severity_counts}"
                 )
-                return Command(
-                    update={
-                        "review": review,
-                        "review_summaries": [summary],
-                        "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
-                    },
-                    goto=END,
-                )
-            review.update({"final_decision": "accept", "export_ready": True, "phase": "complete"})
-            summary = {
-                "plan_number": plan_number,
-                "cycle_number": cycle_number,
-                "issue_counts": severity_cts,
-                "decision": "accept",
-                "routing": "END",
-                "rewrites_required_by_assignment": rewrites_req,
-                "replan_budget_exhausted": True,
-            }
-            self._logger.log(
-                f"{log_context} — replan budget exhausted; exporting (no critical issues, major/minor may remain)."
-            )
-            with ResearchDatabase() as research_db:
-                research_db.save_review_event(
-                    session_id=state["session_id"],
-                    cycle_number=cycle_number,
-                    plan_number=plan_number,
-                    scope_type="deck",
-                    scope_id="deck",
-                    # Supervisor-level routing decision event (not a critic check).
-                    check_type="supervisor",
-                    decision="accept",
-                )
-            return Command(
-                update={
-                    "review": review,
-                    "review_summaries": [summary],
-                    "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
-                },
-                goto=END,
-            )
+            return Command(update=updates, goto="plan_executor")
 
-        # No critic results yet for the current checkpoint — launch or relaunch a critic cycle.
-        if not critic_results:
-            next_cycle = max(1, cycle_number + 1)
-            if at_cycle_cap and review.get("last_rewrite_assignment_ids"):
-                if plan_number <= MAX_REPLANS:
-                    last_counts = review.get("last_issue_counts", {"critical": 0, "major": 0, "minor": 0})
-                    return self._replan(state, review, cycle_number, severity_counts=severity_counts)
-                last_counts = review.get("last_issue_counts", {"critical": 0, "major": 0, "minor": 0})
-                return end_after_replan_budget_gone(
-                    last_counts,
-                    review.get("last_rewrites_required_by_assignment", {}),
-                    (
-                        f"[supervisor] critic cycle cap (cycle {cycle_number}): rewrites pending, "
-                        "no new critic batch yet"
-                    ),
-                )
-
-            assignments = _build_critic_assignments(plan=plan, cycle_number=next_cycle)
-            review.update(
-                {
-                    "cycle_number": next_cycle,
-                    "phase": "critic_dispatch",
-                    "pending_critic_assignments": assignments,
-                    "pending_rewrite_assignments": [],
-                    "last_rewrite_assignment_ids": [],
-                    "last_issue_counts": {"critical": 0, "major": 0, "minor": 0},
-                    "last_rewrites_required_by_assignment": {},
-                }
-            )
-            msg = (
-                f"[supervisor] revise: begin critic cycle {next_cycle}"
-                if phase != "complete"
-                else f"[supervisor] revise: restart critic cycle {next_cycle}"
+        if decision == "revise":
+            # This case corresponds to a fresh LLM 'revise' decision with actionable results
+            actionable_results = [r for r in critic_results if r.get("actionable")]
+            rewrite_assignments = _build_rewrite_assignments(
+                plan=plan,
+                results=actionable_results,
+                cycle_number=cycle_number,
             )
             self._logger.log(
-                f"{msg} | dispatch {len(assignments)} critic(s): {_format_dispatch_targets(assignments)}"
+                f"[supervisor] dispatch {len(rewrite_assignments)} slide rewriter(s): "
+                f"{_format_dispatch_targets(rewrite_assignments)}"
             )
-            return Command(update={"review": review, "messages": [msg]}, goto="plan_executor")
-
-        # Post-rewrite: need another critic pass over updated slides.
-        if review.get("last_rewrite_assignment_ids"):
-            if at_cycle_cap:
-                if plan_number <= MAX_REPLANS:
-                    return self._replan(state, review, cycle_number, severity_counts=severity_counts)
-                return end_after_replan_budget_gone(
-                    severity_counts,
-                    rewrites_required,
-                    (
-                        f"[supervisor] critic cycle cap (cycle {cycle_number}): after rewrite pass, "
-                        f"counts={severity_counts}"
-                    ),
-                )
-
-            next_cycle = cycle_number + 1
-            assignments = _build_critic_assignments(plan=plan, cycle_number=next_cycle)
             review.update(
                 {
-                    "cycle_number": next_cycle,
-                    "phase": "critic_dispatch",
-                    "pending_critic_assignments": assignments,
-                    "pending_rewrite_assignments": [],
-                    "last_rewrite_assignment_ids": [],
+                    "phase": "rewrite_dispatch",
+                    "pending_rewrite_assignments": rewrite_assignments,
                     "last_issue_counts": severity_counts,
                     "last_rewrites_required_by_assignment": rewrites_required,
                 }
@@ -630,162 +607,16 @@ class SupervisorAgent(BaseLLMAgent):
                 "plan_number": plan_number,
                 "cycle_number": cycle_number,
                 "issue_counts": severity_counts,
-                "decision": "revise",
-                "routing": "critic_cycle",
+                "decision": decision,
+                "routing": "rewrite_cycle",
                 "rewrites_required_by_assignment": rewrites_required,
             }
-            self._logger.log(
-                f"[supervisor] cycle {cycle_number}: post-rewrite critic pass -> cycle {next_cycle} "
-                f"| dispatch {len(assignments)} critic(s): {_format_dispatch_targets(assignments)} "
-                f"| prior counts={severity_counts}"
-            )
-            return Command(
-                update={
-                    "review": review,
-                    "review_summaries": [summary],
-                    "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
-                },
-                goto="plan_executor",
-            )
-
-        if at_cap_forced:
-            return self._replan(state, review, cycle_number, severity_counts=severity_counts)
-
-        actionable_results = [r for r in critic_results if r.get("actionable")]
-
-        user = build_supervisor_user_prompt(
-            query=state["query"],
-            cycle_number=cycle_number,
-            max_cycles=max_cycles,
-            severity_counts=severity_counts,
-            summaries=summaries,
-            recurring_lines=recurring_lines,
-        )
-
-        result: SupervisorOutput = self._call(
-            [{"role": "user", "content": user}],
-            schema=SupervisorOutput,
-            model="supervisor",
-        )
-        model_decision = result.decision
-        # Return True if any actionable critic result contains at least one
-        # critical- or major-severity issue.
-        has_critical_actionable = any(
-            i.get("severity") == "critical"
-            for r in actionable_results
-            for i in r.get("issues", [])
-        )
-        has_major_actionable = any(
-            i.get("severity") == "major"
-            for r in actionable_results
-            for i in r.get("issues", [])
-        )
-        has_only_persistent_minor_actionable = _all_actionable_issues_are_persistent_minor(
-            actionable_results,
-            recurring,
-        )
-        decision = model_decision
-        if decision == "accept":
-            if has_critical_actionable:
-                decision = "revise"
-            elif not at_cycle_cap and has_major_actionable:
-                decision = "revise"
-            elif not at_cycle_cap and actionable_results and not has_only_persistent_minor_actionable:
-                decision = "revise"
-        elif decision == "revise" and not actionable_results:
-            decision = "accept"
-        if at_cycle_cap and decision == "revise":
-            if plan_number <= MAX_REPLANS:
-                decision = "replan"
-            else:
-                critical_n = int(severity_counts.get("critical") or 0)
-                if critical_n > 0:
-                    return end_after_replan_budget_gone(
-                        severity_counts,
-                        rewrites_required,
-                        (
-                            f"[supervisor] cycle {cycle_number}: critic cycle cap with further "
-                            "revisions needed but replan budget exhausted"
-                        ),
-                    )
-                decision = "accept"
-
-        if decision == "replan" and plan_number > MAX_REPLANS:
-            critical_n = int(severity_counts.get("critical") or 0)
-            if critical_n > 0:
-                return end_after_replan_budget_gone(
-                    severity_counts,
-                    rewrites_required,
-                    (
-                        f"[supervisor] cycle {cycle_number}: model requested replan but replan "
-                        "budget is exhausted"
-                    ),
-                )
-            decision = "accept"
-
-        summary = {
-            "plan_number": plan_number,
-            "cycle_number": cycle_number,
-            "issue_counts": severity_counts,
-            "decision": decision,
-            "routing": (
-                "planner"
-                if decision == "replan"
-                else "rewrite_cycle"
-                if decision == "revise"
-                else "accept"
-            ),
-            "rewrites_required_by_assignment": rewrites_required,
-        }
-        updates: dict = {
-            "review_summaries": [summary],
-            "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
-        }
-
-        _reasoning_one = " ".join((result.reasoning or "").split())
-        _short_reasoning = (
-            _reasoning_one
-            if len(_reasoning_one) <= 240
-            else _reasoning_one[:239] + "…"
-        )
-        self._logger.log(
-            f"[supervisor] cycle {cycle_number}: model={model_decision} -> effective={decision} "
-            f"| counts={severity_counts} | {_short_reasoning}"
-        )
-
-        if decision == "replan":
-            return self._replan(
-                state,
-                review,
-                cycle_number,
-                result=result,
-                severity_counts=severity_counts,
-            )
-
-        if decision == "accept":
-            return self._accept_and_end(
-                state, review, plan_number, cycle_number, severity_counts, rewrites_required
-            )
-
-        rewrite_assignments = _build_rewrite_assignments(
-            plan=plan,
-            results=actionable_results,
-            cycle_number=cycle_number,
-        )
-        self._logger.log(
-            f"[supervisor] dispatch {len(rewrite_assignments)} slide rewriter(s): "
-            f"{_format_dispatch_targets(rewrite_assignments)}"
-        )
-        review.update(
-            {
-                "phase": "rewrite_dispatch",
-                "pending_rewrite_assignments": rewrite_assignments,
-                "last_issue_counts": severity_counts,
-                "last_rewrites_required_by_assignment": rewrites_required,
+            updates = {
+                "review": review,
+                "review_summaries": [summary],
+                "messages": [json.dumps({"supervisor_cycle_summary": summary}, sort_keys=True)],
             }
-        )
-        updates["review"] = review
-        return Command(update=updates, goto="plan_executor")
+            return Command(update=updates, goto="plan_executor")
 
 
 def supervisor_node(state: ResearchState) -> Command:

--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -57,8 +57,8 @@ class _FailureLogger(CustomLogger):
         status = getattr(exc, "status_code", None)
         status_part = f" [{status}]" if status else ""
         msg = str(exc) if exc else ""
-        # Trim the message to the first sentence / newline to keep it short
-        msg = msg.split("\n")[0][:120]
+        # Trim the message to the first newline to keep it short, but don't truncate length
+        msg = msg.split("\n")[0][:180]
         return f"[{agent}] Deployment failed: {model} — {exc_type}{status_part}: {msg}"
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):  # noqa: ANN001
@@ -481,6 +481,7 @@ def should_fallback_to_json_object(exc: Exception) -> bool:
         "extra_forbidden",
         "extra inputs are not permitted",
         "extra inputs not permitted",
+        "invalid grammar",
     )
     return any(marker in message for marker in fallback_markers)
 

--- a/tests/test_supervisor_replan.py
+++ b/tests/test_supervisor_replan.py
@@ -172,9 +172,9 @@ class TestSupervisorReplan(unittest.TestCase):
         }
         cmd = SupervisorAgent().run(state)
         self.assertEqual(cmd.goto, END)
-        self.assertFalse(cmd.update["review"].get("export_ready"))
-        self.assertIsNone(cmd.update["review"].get("final_decision"))
-        mock_db.save_review_event.assert_not_called()
+        self.assertTrue(cmd.update["review"].get("export_ready"))
+        self.assertEqual(cmd.update["review"].get("final_decision"), "accept")
+        mock_db.save_review_event.assert_called()
 
     @patch("src.agents.supervisor.ResearchDatabase")
     def test_below_cap_flag_does_not_force_replan(self, mock_db_class: MagicMock) -> None:
@@ -368,7 +368,7 @@ class TestForceAcceptFirstPlan(unittest.TestCase):
         self.assertEqual(cmd.update["review"]["final_decision"], "accept")
         s0 = cmd.update["review_summaries"][0]
         self.assertEqual(s0["decision"], "accept")
-        self.assertEqual(s0["routing"], "accept")
+        self.assertEqual(s0["routing"], "END")
         mock_backup.assert_not_called()
 
     @patch("src.agents.supervisor.backup_replan_debug_snapshot")


### PR DESCRIPTION
Refactored supervisor to much cleaner logic.
Added another case for possible json_schema failure in llm.py to address deepseek-v3.2's "invalid grammar".
Updated supervisor prompt.
Made supervisorOutput's decision literal instead of str.
Mistral needs specific tool_id format.